### PR TITLE
Don't use -c for Darwin ranlib

### DIFF
--- a/share/gprconfig/linker.xml
+++ b/share/gprconfig/linker.xml
@@ -933,7 +933,6 @@
 
    for Shared_Library_Suffix use ".dylib";
    for Library_Auto_Init_Supported use "true";
-   for Archive_Indexer use project'Archive_Indexer &amp; ("-c");
    for Shared_Library_Minimum_Switches use
          ("-dynamiclib", "-shared-libgcc");
    for Library_Encapsulated_Options use ("-shared", "-static-libgcc");


### PR DESCRIPTION
See GCC bug 42554 <http://gcc.gnu.org/bugzilla/show_bug.cgi?id=42554>
and [KA07-020 public].

"ranlib -c" is disapproved of by Apple, "This is seldom the intended
behavior for linking from a library, as it forces the linking of a
library member just because it uses an uninitialized global that is
undefined at that point in the linking. This option is included only
because this was the original behavior of ranlib. This option is not
the default."

  * share/gprconfig/linker.xml (Darwin): don't add -c flag to
      Archive_Indexer