### PR TITLE
Rewrite bootstrap.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,17 @@ easily bootstrap if you don't already have `gprbuild`, provided you
 already have installed GNAT.
 
 Download XML/Ada sources (from https://github.com/AdaCore/xmlada).
-Run the `bootstrap.sh` script (written for Linux) specifying the install
-location and the sources of XML/Ada. The script will build *and*
-install `gprbuild`:
+Run the `bootstrap.sh` script (written for POSIX systems) specifying the
+install location and the sources of XML/Ada. The script will build *and*
+install `gprbuild`.
 
-    $ ../bootstrap.sh --with-xmlada=../../xmlada.git --prefix=$HOME/bootstrap
+For example, to build `gprbuild` and install it to `./bootstrap` in the current
+working directory, run:
+
+    $ ./bootstrap.sh --with-xmlada=../xmlada --prefix=./bootstrap
+
+For maintainers, the environment `DESTDIR` is honoured for staged installs, see
+`./bootstrap.sh -h` for more.
 
 With this bootstrapped `gprbuild`, you can build XML/Ada and `gprbuild`
 as documented below.


### PR DESCRIPTION
This rewrite was primarily motivated by the need to fix an issue where
GNATMAKEFLAGS was causing failure when called on the command-line:

    ./bootstrap.sh: unknown option GNATMAKEFLAGS=-bargs -E; try ./bootstrap.sh --help
    ./bootstrap.sh: unknown option --GNATMAKEFLAGS=-bargs -E; try ./bootstrap.sh --help

However, I took the opportunity to clean up the script, removing several
flaws while producing something more idiomatic while still retaining
POSIX compliance.

A new feature I've included is support for staged installs [1] via the
DESTDIR environment to make my life a little easier and allowing for you
to eventually honour GNU's install directories [2] in the rest of the code
base without needing to change the semantics of this script.

I've also removed the surprising behaviour of passing environment
variables in as command-line arguments to scripts by making them
explicitly environmental.

Lastly I've removed the assumptions around $0 and where to find the
directory the script was executed from.  This is completely unreliable
and should never be used. [3]

I think the result is cleaner, clearer and more easily adapted to new
requirements

1. https://www.gnu.org/prep/standards/html_node/DESTDIR.html
2. https://www.gnu.org/prep/standards/html_node/Directory-Variables.html
3. http://mywiki.wooledge.org/BashFAQ/028

Signed-off-by: Earnestly <zibeon@googlemail.com>