### PR TITLE
Initialize the record of temp file paths to be deleted.

### DIFF
--- a/gpr/src/gpr.adb
+++ b/gpr/src/gpr.adb
@@ -2279,4 +2279,6 @@ package body GPR is
       Flags.Ignore_Missing_With := Value;
    end Set_Ignore_Missing_With;
 
+begin
+   Temp_Files_Table.Init (Temp_Files);
 end GPR;


### PR DESCRIPTION
This proposed change is in response to AdaCore/xmlada#3, where building a relocatable library using a recent gprbuild built with GNAT GPL 2016 (or GCC 6.1.0) resulted in

    raised CONSTRAINT_ERROR : g-dyntab.adb:259 access check failed
    gprbuild: could not build library for project xmlada_unicode

This problem arose with 5f98f94, where `Temp_Files` was added to `gpr.adb` but not initialized (i.e. only default-initialized). Other instances of `GNAT.Dynamic_Tables` are used in the code, but they are all initialized (using `GNAT.Dynamic_Tables.Init`). It appears that a default-initialized instance works without an explicit `Init` in GCC 7, and, I’m sure, AdaCore’s current compilers.