### PR TITLE
Detection of shared setting seems wrong

### DIFF
--- a/src/gprbuild-post_compile.adb
+++ b/src/gprbuild-post_compile.adb
@@ -4763,7 +4763,9 @@ package body Gprbuild.Post_Compile is
                                  No_Create => Proj.Is_Aggregated);
                            end if;
 
-                           Shared_Libs := not Is_Static (Proj.Proj);
+                           if not Is_Static (Proj.Proj);
+                              Shared_Libs := true;
+                           end if;
 
                         end if;
                      end if;

--- a/src/gprbuild-post_compile.adb
+++ b/src/gprbuild-post_compile.adb
@@ -4763,7 +4763,7 @@ package body Gprbuild.Post_Compile is
                                  No_Create => Proj.Is_Aggregated);
                            end if;
 
-                           if not Is_Static (Proj.Proj);
+                           if not Is_Static (Proj.Proj) then
                               Shared_Libs := true;
                            end if;
 


### PR DESCRIPTION
It seems to me that the whole project is linked static or shared if the last project in the list is static or not.
I guess it should be shared if at least a project is not static.
Am I wrong ?
ps.
Please do not merge this like it is. I wrote an if in bash syntax :(