### PR TITLE
Fix gpr.snames constants

### DIFF
--- a/gpr/src/gpr-names.adb
+++ b/gpr/src/gpr-names.adb
@@ -354,6 +354,8 @@ package body GPR.Names is
 
       Name_Chars.Append (ASCII.NUL);
 
+      Last_Id := Name_Entries.Last;
+
       return Name_Entries.Last;
    end Name_Enter;
 
@@ -426,6 +428,8 @@ package body GPR.Names is
       end loop;
 
       Name_Chars.Append (ASCII.NUL);
+
+      Last_Id := Name_Entries.Last;
 
       return Name_Entries.Last;
    end Name_Find;

--- a/gpr/src/gpr-names.ads
+++ b/gpr/src/gpr-names.ads
@@ -27,6 +27,8 @@ package GPR.Names is
    Name_Buffer : String (1 .. 1_000_000);
    Name_Len    : Natural := 0;
 
+   Last_Id     : Name_Id := Name_Id'First;
+
    procedure Get_Name_String (Id : Name_Id);
    procedure Get_Name_String (Id : Unit_Name_Type);
    procedure Get_Name_String (Id : File_Name_Type);

--- a/gpr/src/gpr-snames.adb
+++ b/gpr/src/gpr-snames.adb
@@ -53,6 +53,10 @@ package body GPR.Snames is
          return;
       end if;
 
+      if Last_Id = Name_Id'First then
+         Add_Name ("");
+      end if;
+
       Add_Name ("a");
       Add_Name ("b");
       Add_Name ("c");


### PR DESCRIPTION
It seems to me that the values of the various Names_XXX constants in gpr.snames are correct only if the gpr.snames.initialize is called after a first append.
That is done in gprbuild during the elaboration part of gpr.util.

My patch, terribly ugly, is done by exporting a variable that tell what is the last Name_Id inserted, and checking it during the snames.initialize