### PR TITLE
Fix rpath bug - check that Run_Path_Origin is set before using

### DIFF
--- a/share/gprconfig/linker.xml
+++ b/share/gprconfig/linker.xml
@@ -961,11 +961,12 @@
     </config>
   </configuration>
 
-  <!-- linux, QNX -->
+  <!-- linux, freebsd, QNX -->
   <configuration>
     <targets>
        <target name="^.*linux.*$" />
        <target name="^.*qnx[0-9]*$" />
+       <target name="^.*freebsd.*$" />
     </targets>
     <config>
    for Run_Path_Option  use ("-Wl,-z,origin,-rpath,");
@@ -1048,16 +1049,6 @@
     </targets>
     <config>
     for Library_Rpath_Options ("C++") use ("-print-file-name=libstdc++.so");
-    </config>
-  </configuration>
-
-  <!-- freebsd -->
-  <configuration>
-    <targets>
-       <target name="^.*freebsd.*$" />
-    </targets>
-    <config>
-   for Run_Path_Option  use ("-Wl,-rpath,");
     </config>
   </configuration>
 

--- a/src/gprbuild-post_compile.adb
+++ b/src/gprbuild-post_compile.adb
@@ -1750,9 +1750,12 @@ package body Gprbuild.Post_Compile is
             Write_Name_List (Exchange_File, Run_Path_Option, List);
             Put_Line (Exchange_File,
                       Library_Label (Gprexch.Run_Path_Origin));
-            Put_Line (Exchange_File,
-                      Get_Name_String (For_Project.Config.Run_Path_Origin));
-
+            
+            if For_Project.Config.Run_Path_Origin /= No_Name then
+               Put_Line (Exchange_File,
+                         Get_Name_String (For_Project.Config.Run_Path_Origin));
+            end if;
+               
             if For_Project.Config.Separate_Run_Path_Options then
                Put_Line
                  (Exchange_File,

--- a/src/gprlib.adb
+++ b/src/gprlib.adb
@@ -356,7 +356,8 @@ procedure Gprlib is
       Relative : constant String :=
                    Relative_RPath (Path,
                                    Library_Directory.all,
-                                   Rpath_Origin.all);
+                                   (if Rpath_Origin = null then ""
+                                      else Rpath_Origin.all));
 
    begin
       if Path'Length = 0 then


### PR DESCRIPTION
Bootstrap of gprbuild on FreeBSD created a gprbuild which failed due to a Constraint_Error exception when attempting to look up No_Name (0) Name_Id's string. The failure occurred when an attempt is made to reference the Config.Run_Path_Origin value of a project.

Adding logic to first check that this property is set, a similar issue appeared with an attempt to deference a null String access type for the same "run path origin" when generating a relative path.