### PR TITLE
update gpr/snames.list

### DIFF
--- a/gpr/snames.list
+++ b/gpr/snames.list
@@ -290,3 +290,5 @@ Canonical_Target
 Warning_Message
 Only_Dirs_With_Sources
 Include_Switches_Via_Spec
+Required_Toolchain_Version
+Toolchain_Name


### PR DESCRIPTION
gpr/src/gpr-snames.ad[bs] are supposed to be generated from gpr/snames.list.
AdaCore distributes recent versions, but with an obsolete template.
Debian spots this by rebuilding everything.
Add missing definitions to the template.