### PR TITLE
Make the bootstrap script POSIX compliant.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # bootstrap.sh - a simple bootstrap for building gprbuild with xmlada
 
 progname=bootstrap
@@ -46,7 +46,7 @@ exit 0
 }
 
 error() {
-    printf -- "%s: $1" "$progname" "${@:2}" >&2
+    printf -- "%s: $1" "$progname" "$(echo "$@" | cut -c 3-)" >&2
     exit 1
 }
 
@@ -86,7 +86,7 @@ rm -rf "$srcdir"/share/gprconfig
 cp -r "$kb_src"/db "$srcdir"/share/gprconfig
 
 # Build
-if [ "x"${MODE} == "x" ] || [ ${MODE} == "build" ];
+if [ "x"${MODE} = "x" ] || [ ${MODE} = "build" ];
 then
 	command $CC -c $CFLAGS "$srcdir"/gpr/src/gpr_imports.c
 
@@ -101,7 +101,7 @@ fi;
 
 # Install
 
-if [ "x"${MODE} == "x" ]  || [ ${MODE} == "install" ];
+if [ "x"${MODE} = "x" ]  || [ ${MODE} = "install" ];
 then
 	mkdir -p "$DESTDIR$prefix$bindir"
 	mkdir -p "$DESTDIR$prefix$libexecdir"/gprbuild


### PR DESCRIPTION
The bootstrap.sh script currently makes use of bash. However, in some systems it is not installed by default and if it is installed, it is not in the /bin/bash path. This PR changes the bootstrap.sh script to use the POSIX compliant /bin/sh and makes sure to only use POSIX shell syntax.

## Why?
Because it makes it easier to port gprbuild to other *NIX platforms, which is where a bootstrap is generally needed.

## What changed?

Use `/bin/sh` by default

POSIX shell does not allow for array slicing (see the error function). I have modified it to use `cut`, which is the recommended way as per https://github.com/koalaman/shellcheck/wiki/SC3057

The double equals signs are also undefined in POSIX, they were changed to simple `=`, this is the recommended way as indicated in https://github.com/koalaman/shellcheck/wiki/SC3014

If the shell script (either the original or the one with this modifications) is analysed with https://www.shellcheck.net/ some stylistic changes are recommended, however, I have not included them here.

## Extra

Could this change be backported to V21? Master does not build with GCC 10.3.0, V21 does. V21 has the issue where some  `install` instruction use `-t`, which is redundant and not POSIX compliant too. Those `-t` flags have been removed from master.

Thank you,
Fer