### PR TITLE
Fix build on Netbsd with gcc 10.3.0

### DIFF
--- a/gpr/src/gpr-osint.ads
+++ b/gpr/src/gpr-osint.ads
@@ -230,7 +230,7 @@ package GPR.Osint is
 private
 
    function File_Time_Stamp (N : C_File_Name) return Ada.Calendar.Time
-     with Import, Convention => C, External_Name => "__gnat_file_time";
+     with Import, Convention => C, External_Name => "__gnat_file_time_name";
 
    Invalid_Time : constant Ada.Calendar.Time :=
                     File_Time_Stamp (System.Null_Address);

--- a/src/gprbind.adb
+++ b/src/gprbind.adb
@@ -617,7 +617,7 @@ begin
       Gnatbind_Options.Append ("-F");
    end if;
 
-   Gnatbind_Options.Append_Vector (ALI_Files_Table);
+   Gnatbind_Options.Append (ALI_Files_Table);
 
    for Option of Binding_Options_Table loop
       Gnatbind_Options.Append (Option);
@@ -984,7 +984,7 @@ begin
       Compiler_Options.Append (Object);
 
       --  Add the trailing options, if any
-      Compiler_Options.Append_Vector (Compiler_Trailing_Options);
+      Compiler_Options.Append (Compiler_Trailing_Options);
 
       if Verbose_Low_Mode then
          Set_Name_Buffer (Ada_Compiler_Path.all);

--- a/src/gprbuild-link.adb
+++ b/src/gprbuild-link.adb
@@ -762,7 +762,7 @@ package body Gprbuild.Link is
 
       while Proj_List /= null loop
          if not Proj_List.Project.Library then
-            Objects.Append_Vector (Get_Objects (Proj_List.Project));
+            Objects.Append (Get_Objects (Proj_List.Project));
          end if;
 
          Proj_List := Proj_List.Next;
@@ -796,10 +796,10 @@ package body Gprbuild.Link is
 
          if First_Object = Objects.First_Index then
             --  Creation of a new archive
-            Arguments.Append_Vector (Archive_Builder_Opts);
+            Arguments.Append (Archive_Builder_Opts);
          else
             --  Append objects to an existing archive
-            Arguments.Append_Vector (Archive_Builder_Append_Opts);
+            Arguments.Append (Archive_Builder_Append_Opts);
          end if;
 
          --  Followed by the archive name
@@ -885,7 +885,7 @@ package body Gprbuild.Link is
          Arguments.Clear;
          Command.Clear;
 
-         Arguments.Append_Vector (Archive_Indexer_Opts);
+         Arguments.Append (Archive_Indexer_Opts);
          Add_Argument
            (Arguments,
             Archive_Name,
@@ -3428,7 +3428,7 @@ package body Gprbuild.Link is
                            --  argument(s). Update Arguments_Displayed
                            --  too.
 
-                           Arguments.Append_Vector (Other_Arguments);
+                           Arguments.Append (Other_Arguments);
                            Other_Arguments.Clear;
                         end if;
                      end;
@@ -3447,7 +3447,7 @@ package body Gprbuild.Link is
                not Opt.Verbose_Mode);
          end loop;
 
-         Arguments.Append_Vector (Other_Arguments);
+         Arguments.Append (Other_Arguments);
 
          Objects.Clear;
          Other_Arguments.Clear;

--- a/src/gprinstall-install.adb
+++ b/src/gprinstall-install.adb
@@ -1802,7 +1802,7 @@ package body Gprinstall.Install is
                Content.Append ("      case BUILD is");
 
                if P /= No_Package then
-                  Content.Append_Vector (Naming_Case_Alternative (Proj));
+                  Content.Append (Naming_Case_Alternative (Proj));
                end if;
 
                Content.Append ("      end case;");
@@ -1823,7 +1823,7 @@ package body Gprinstall.Install is
                --  Attribute Linker_Options only if set
 
                if P /= No_Package then
-                  Content.Append_Vector (Linker_Case_Alternative (Proj));
+                  Content.Append (Linker_Case_Alternative (Proj));
                end if;
 
                Content.Append ("      end case;");
@@ -2709,18 +2709,18 @@ package body Gprinstall.Install is
                      case Current_Section is
                         when Naming =>
                            String_Vector.Next (Pos);
-                           Content.Insert_Vector
+                           Content.Insert
                              (Pos, Naming_Case_Alternative (Project));
 
                         when Linker =>
                            String_Vector.Next (Pos);
-                           Content.Insert_Vector
+                           Content.Insert
                              (Pos, Linker_Case_Alternative (Project));
 
                         when Top =>
                            --  For the Sources/Lib attributes
                            String_Vector.Next (Pos);
-                           Content.Insert_Vector (Pos, Data_Attributes);
+                           Content.Insert (Pos, Data_Attributes);
                      end case;
 
                   elsif Fixed.Index (Line, "when """ & BN & """ =>") /= 0 then
@@ -2880,7 +2880,7 @@ package body Gprinstall.Install is
                Add_Empty_Line;
 
                Content.Append ("   case BUILD is");
-               Content.Append_Vector (Data_Attributes);
+               Content.Append (Data_Attributes);
                Content.Append ("   end case;");
 
                Add_Empty_Line;

--- a/src/gprlib-build_shared_lib.adb
+++ b/src/gprlib-build_shared_lib.adb
@@ -110,10 +110,10 @@ procedure Build_Shared_Lib is
       --  Argument_Length := Driver'Length;
 
       --  The minimum arguments
-      Arguments.Append_Vector (Shared_Lib_Minimum_Options);
+      Arguments.Append (Shared_Lib_Minimum_Options);
 
       --  The leading library options, if any
-      Arguments.Append_Vector (Leading_Library_Options_Table);
+      Arguments.Append (Leading_Library_Options_Table);
 
       --  -o <library file name>
 
@@ -255,13 +255,13 @@ procedure Build_Shared_Lib is
       --  Finally the additional switches, the library switches and the library
       --  options.
 
-      Arguments.Append_Vector (Additional_Switches);
+      Arguments.Append (Additional_Switches);
 
-      Arguments.Append_Vector (Library_Switches_Table);
+      Arguments.Append (Library_Switches_Table);
 
-      Arguments.Append_Vector (Ada_Runtime_Switches);
+      Arguments.Append (Ada_Runtime_Switches);
 
-      Arguments.Append_Vector (Library_Options_Table);
+      Arguments.Append (Library_Options_Table);
 
       --  Check if a response file is needed
       if Max_Command_Line_Length > 0
@@ -323,11 +323,11 @@ procedure Build_Shared_Lib is
                        (Response_File_Switches.Last_Index,
                         Response_File_Switches.Last_Element &
                           Get_Name_String (Response_File_Name));
-                     Arguments.Append_Vector (Response_File_Switches);
+                     Arguments.Append (Response_File_Switches);
                   end if;
 
                   --  Put back the options
-                  Arguments.Append_Vector (Options);
+                  Arguments.Append (Options);
                end if;
             end if;
          end;
@@ -369,7 +369,7 @@ procedure Build_Shared_Lib is
                --  We need to add the binder generated object file which
                --  contains the library initilization code to be explicitely
                --  called by the main application.
-               List.Append_Vector (Generated_Objects);
+               List.Append (Generated_Objects);
 
                Aux.Create_Export_Symbols_File
                  (Driver_Path         => Object_Lister.all,

--- a/src/gprlib.adb
+++ b/src/gprlib.adb
@@ -1045,7 +1045,7 @@ procedure Gprlib is
             end if;
          end if;
 
-         Bind_Options.Append_Vector (Binding_Options_Table);
+         Bind_Options.Append (Binding_Options_Table);
 
          --  Get an eventual --RTS from the ALI file
 
@@ -1085,7 +1085,7 @@ procedure Gprlib is
             end loop;
          end if;
 
-         Bind_Options.Append_Vector (ALIs);
+         Bind_Options.Append (ALIs);
 
          if Mapping_File_Name /= null then
             Bind_Options.Append ("-F=" & Mapping_File_Name.all);
@@ -1281,7 +1281,7 @@ procedure Gprlib is
 
          Bind_Options := String_Vectors.Empty_Vector;
 
-         Bind_Options.Append_Vector (Ada_Leading_Switches);
+         Bind_Options.Append (Ada_Leading_Switches);
          Bind_Options.Append (No_Warning);
          Bind_Options.Append (Binder_Generated_File);
          Bind_Options.Append (Output_Switch);
@@ -1330,7 +1330,7 @@ procedure Gprlib is
             end loop;
          end if;
 
-         Bind_Options.Append_Vector (Ada_Trailing_Switches);
+         Bind_Options.Append (Ada_Trailing_Switches);
 
          if not Quiet_Output then
             Name_Len := 0;
@@ -1535,7 +1535,7 @@ procedure Gprlib is
                     or else Size >= Maximum_Size;
                end loop;
 
-               PL_Options.Append_Vector (Trailing_PL_Options);
+               PL_Options.Append (Trailing_PL_Options);
 
                if not Quiet_Output then
                   if Verbose_Mode then
@@ -1576,7 +1576,7 @@ procedure Gprlib is
          --  Not a standalone library, or Partial linker is not specified.
          --  Put all objects in the archive.
 
-         AB_Objects.Append_Vector (Object_Files);
+         AB_Objects.Append (Object_Files);
       end if;
 
       --  Add the .GPR.linker_options section to Linker_Option_Object_File.
@@ -1724,7 +1724,7 @@ procedure Gprlib is
             --  archive in one chunk.
 
             AB_Options := AB_Create_Options;
-            AB_Options.Append_Vector (AB_Objects);
+            AB_Options.Append (AB_Objects);
             First_AB_Object_Pos := AB_Objects.Last_Index + 1;
 
          else
@@ -1753,7 +1753,7 @@ procedure Gprlib is
                Last_AB_Object_Pos := J;
             end loop;
 
-            AB_Options.Append_Vector
+            AB_Options.Append
               (Slice (AB_Objects, First_AB_Object_Pos, Last_AB_Object_Pos));
 
             --  Display the invocation of the archive builder for the creation


### PR DESCRIPTION
On Netbsd we now have gcc 10.3.0, thanks to @Irvise for this port, but `gprbuild` does not compile because

* it uses an internal GCC method `__gnat_file_time` whose name is `__gnat_file_time_name` is GCC 10.3.0,
* it uses the `Ada.Containers.Vectors.Append_Vector` and `Insert_Vector` procedures which are not available.

This pull request contains changes that fixes the build on Netbsd.
I'm doing this more as a friendly notification and not really as a request to merge this in your branch.