### PR TITLE
Update gpr-util.adb

### DIFF
--- a/gpr/src/gpr-util.adb
+++ b/gpr/src/gpr-util.adb
@@ -3631,7 +3631,7 @@ package body GPR.Util is
             end if;
          end loop;
 
-         return Ret;
+         return Ret(1 .. Length - Separator'Length);
       end;
    end Concat_Paths;
 


### PR DESCRIPTION
Fix Concat_Paths by not adding an extra separator at the end.
On its use, while concatenating run_path, it was adding a null DT_RUNPATH.
That is signaled as a security problem
(I think can be used to load shared libraries from the current path so could change the behaviour of a program)