### PR TITLE
prefer short circuit

### DIFF
--- a/gpr/src/gpr-ali.adb
+++ b/gpr/src/gpr-ali.adb
@@ -319,7 +319,7 @@ package body GPR.ALI is
          --  sensitive. This ensures that we handle names in the canonical
          --  lower case format, regardless of the actual case.
 
-         if Lower and not File_Names_Case_Sensitive then
+         if Lower and then not File_Names_Case_Sensitive then
             Canonical_Case_File_Name (Name_Buffer (1 .. Name_Len));
             return Name_Find;
          else

--- a/gpr/src/gpr-compilation-slave.adb
+++ b/gpr/src/gpr-compilation-slave.adb
@@ -883,7 +883,7 @@ package body GPR.Compilation.Slave is
             --  We are past the random slave and we have found one slave ready,
             --  stop search here.
 
-            exit Search_Slaves when K > Index and Result /= No_Slave;
+            exit Search_Slaves when K > Index and then Result /= No_Slave;
          end loop Search_Slaves;
 
          return Result;

--- a/gpr/src/gpr-compilation-sync.adb
+++ b/gpr/src/gpr-compilation-sync.adb
@@ -121,16 +121,16 @@ package body GPR.Compilation.Sync is
       ---------
 
       entry Get
-        (Job   : out Gpr_Data;
-         Files : out File_Data_Set.Vector;
-         Stop  : out Boolean) when Jobs.Length > 0 or No_More is
+        (Job  : out Gpr_Data; Files : out File_Data_Set.Vector;
+         Stop : out Boolean)
+        when Jobs.Length > 0 or else No_More is
       begin
          if Jobs.Length = 0 and then No_More then
             Stop := True;
 
          else
             Stop := False;
-            Job := Jobs.First_Element;
+            Job  := Jobs.First_Element;
             Jobs.Delete_First;
 
             if not PF_Initialized then

--- a/gpr/src/gpr-conf.adb
+++ b/gpr/src/gpr-conf.adb
@@ -1936,7 +1936,7 @@ package body GPR.Conf is
       --  at the compiler roots.
 
       Config_Try_Again :=
-        Fallback_Try_Again or Project_Node_Tree.Incomplete_With;
+        Fallback_Try_Again or else Project_Node_Tree.Incomplete_With;
 
       Process_Project_And_Apply_Config
         (Main_Project               => Main_Project,

--- a/gpr/src/gpr-dect.adb
+++ b/gpr/src/gpr-dect.adb
@@ -1021,10 +1021,9 @@ package body GPR.Dect is
       end loop When_Loop;
 
       End_Case_Construction
-        (Check_All_Labels => not When_Others and not Quiet_Output,
+        (Check_All_Labels => not When_Others and then not Quiet_Output,
          Case_Location    => Location_Of (Case_Construction, In_Tree),
-         Flags            => Flags,
-         String_Type      => Present (String_Type));
+         Flags            => Flags, String_Type => Present (String_Type));
 
       Expect (Tok_End, "`END CASE`");
       Remove_Next_End_Node;

--- a/gpr/src/gpr-env.adb
+++ b/gpr/src/gpr-env.adb
@@ -1732,7 +1732,7 @@ package body GPR.Env is
       --  For the object path, we make a distinction depending on
       --  Including_Libraries.
 
-      if Objects_Path and Including_Libraries then
+      if Objects_Path and then Including_Libraries then
          if Project.Objects_Path_File_With_Libs = No_Path then
             Object_Path_Table.Init (Object_Paths);
             Process_Object_Dirs := True;
@@ -1752,7 +1752,7 @@ package body GPR.Env is
       --  If there is something to do, set Seen to False for all projects,
       --  then call the recursive procedure Add for Project.
 
-      if Process_Source_Dirs or Process_Object_Dirs then
+      if Process_Source_Dirs or else Process_Object_Dirs then
          For_All_Projects (Project, In_Tree, Dummy);
       end if;
 

--- a/gpr/src/gpr-err.adb
+++ b/gpr/src/gpr-err.adb
@@ -112,7 +112,7 @@ package body GPR.Err is
 
       --  Kill continuation if parent message killed
 
-      if Continuation and Last_Killed then
+      if Continuation and then Last_Killed then
          return;
       end if;
 
@@ -281,7 +281,7 @@ package body GPR.Err is
 
       --  Brief Error mode
 
-      if Brief_Output or not Verbose_Mode then
+      if Brief_Output or else not Verbose_Mode then
          E := First_Error_Msg;
          Set_Standard_Error;
 

--- a/gpr/src/gpr-knowledge.adb
+++ b/gpr/src/gpr-knowledge.adb
@@ -3962,44 +3962,42 @@ package body GPR.Knowledge is
 
             if (not From_Extra_Dir or else El.Path = Comp.Path)
               and then Filter_Match (Base, Comp => Comp, Filter => El.all)
-              and then (not Runtime_Specified or El.Runtime_Dir /= No_Name)
+              and then
+              (not Runtime_Specified or else El.Runtime_Dir /= No_Name)
             then
                Ncomp := new Compiler'(Comp);
                if El.Runtime_Dir /= No_Name then
                   Ncomp.Runtime_Dir := El.Runtime_Dir;
-                  Ncomp.Runtime := El.Runtime;
+                  Ncomp.Runtime     := El.Runtime;
                end if;
 
-               if not Ncomp.Any_Runtime
-                 and then Ncomp.Runtime = No_Name
+               if not Ncomp.Any_Runtime and then Ncomp.Runtime = No_Name
                  and then El.Runtime /= No_Name
                then
-                     Ncomp.Runtime := El.Runtime;
+                  Ncomp.Runtime := El.Runtime;
                end if;
 
                Append (Iterator.Compilers, Ncomp);
 
                if Current_Verbosity /= Default then
                   Put_Verbose
-                    ("Saving compiler for possible backtracking: "
-                     & To_String (Base, Ncomp.all, As_Config_Arg => True)
-                     & " (matches --config "
-                     & To_String (Base, El.all, As_Config_Arg => True)
-                     & ")");
+                    ("Saving compiler for possible backtracking: " &
+                     To_String (Base, Ncomp.all, As_Config_Arg => True) &
+                     " (matches --config " &
+                     To_String (Base, El.all, As_Config_Arg => True) & ")");
                end if;
 
                if Iterator.Matched (Index) = Compiler_Lists.No_Element then
                   Iterator.Found := Iterator.Found + 1;
 
                   Put_Verbose
-                    ("Selecting it since this filter was not matched yet "
-                     & Iterator.Found'Img & "/" & Iterator.Count'Img);
+                    ("Selecting it since this filter was not matched yet " &
+                     Iterator.Found'Img & "/" & Iterator.Count'Img);
 
-                  Iterator.Matched (Index) := Last (Iterator.Compilers);
+                  Iterator.Matched (Index)   := Last (Iterator.Compilers);
                   Iterator.Found_One (Index) := True;
                   Set_Selection
-                    (Iterator.Compilers, Iterator.Matched (Index),
-                     True);
+                    (Iterator.Compilers, Iterator.Matched (Index), True);
 
                   --  Only keep those compilers that are not incompatible
                   --  (according to the knowledge base). It might happen that
@@ -4013,10 +4011,10 @@ package body GPR.Knowledge is
                      Set_Selection
                        (Iterator.Compilers, Iterator.Matched (Index), False);
                      Put_Verbose
-                       ("Compilers are not compatible, cancelling last"
-                        & " compiler found");
+                       ("Compilers are not compatible, cancelling last" &
+                        " compiler found");
                      Iterator.Matched (Index) := Compiler_Lists.No_Element;
-                     Iterator.Found := Iterator.Found - 1;
+                     Iterator.Found           := Iterator.Found - 1;
                   end if;
                end if;
             end if;

--- a/gpr/src/gpr-nmsc.adb
+++ b/gpr/src/gpr-nmsc.adb
@@ -4514,12 +4514,11 @@ package body GPR.Nmsc is
          Check_Aggregate_Library_Dirs;
       end if;
 
-      if Project.Library and not Data.In_Aggregate_Lib then
+      if Project.Library and then not Data.In_Aggregate_Lib then
          --  Record the library name
 
          Lib_Data_Table.Append
-           ((Name => Project.Library_Name,
-             Proj => Project,
+           ((Name => Project.Library_Name, Proj => Project,
              Tree => Data.Tree));
       end if;
    end Check_Library_Attributes;
@@ -5513,7 +5512,7 @@ package body GPR.Nmsc is
                end if;
             end loop;
 
-            OK := OK and not Underline;
+            OK := OK and then not Underline;
 
             if not OK then
                Error_Msg
@@ -7130,28 +7129,25 @@ package body GPR.Nmsc is
 
          Dir_Exists := Is_Directory (Full_Path_Name.all);
 
-         if not Must_Exist or Dir_Exists then
+         if not Must_Exist or else Dir_Exists then
             declare
                Normed : constant String :=
-                          Normalize_Pathname
-                            (Full_Path_Name.all,
-                             Directory      =>
-                              The_Parent (The_Parent'First .. The_Parent_Last),
-                             Resolve_Links  => False,
-                             Case_Sensitive => True);
+                 Normalize_Pathname
+                   (Full_Path_Name.all,
+                    Directory =>
+                      The_Parent (The_Parent'First .. The_Parent_Last),
+                    Resolve_Links => False, Case_Sensitive => True);
 
                Canonical_Path : constant String :=
-                                  Normalize_Pathname
-                                    (Normed,
-                                     Directory      =>
-                                       The_Parent
-                                         (The_Parent'First .. The_Parent_Last),
-                                     Resolve_Links  =>
-                                        Opt.Follow_Links_For_Dirs,
-                                     Case_Sensitive => False);
+                 Normalize_Pathname
+                   (Normed,
+                    Directory =>
+                      The_Parent (The_Parent'First .. The_Parent_Last),
+                    Resolve_Links  => Opt.Follow_Links_For_Dirs,
+                    Case_Sensitive => False);
 
             begin
-               Name_Len := Normed'Length;
+               Name_Len                    := Normed'Length;
                Name_Buffer (1 .. Name_Len) := Normed;
 
                --  Directories should always end with a directory separator
@@ -7162,7 +7158,7 @@ package body GPR.Nmsc is
 
                Path.Display_Name := Name_Find;
 
-               Name_Len := Canonical_Path'Length;
+               Name_Len                    := Canonical_Path'Length;
                Name_Buffer (1 .. Name_Len) := Canonical_Path;
 
                if Name_Buffer (Name_Len) /= Directory_Separator then
@@ -8219,7 +8215,7 @@ package body GPR.Nmsc is
 
          Recursive_Dirs.Set (Visited, Path.Name, True);
 
-         Success := Subdirectory_Matches (Path, Rank) or Success;
+         Success := Subdirectory_Matches (Path, Rank) or else Success;
 
          Open (Dir, Path_Str);
 
@@ -8277,7 +8273,7 @@ package body GPR.Nmsc is
                         Path2.Name := Name_Find;
 
                         Success :=
-                          Recursive_Find_Dirs (Path2, Rank) or Success;
+                          Recursive_Find_Dirs (Path2, Rank) or else Success;
                      end if;
                   end if;
                end;
@@ -9427,7 +9423,7 @@ package body GPR.Nmsc is
                --  it as it has no sources by itself and so interface won't be
                --  found.
 
-               if Project.Library and not In_Aggregate_Lib then
+               if Project.Library and then not In_Aggregate_Lib then
                   Check_Stand_Alone_Library (Project, Data);
                end if;
 

--- a/gpr/src/gpr-part.adb
+++ b/gpr/src/gpr-part.adb
@@ -999,14 +999,14 @@ package body GPR.Part is
                   --  If we have one, get the project id of the limited
                   --  imported project file, and do not parse it.
 
-                  if (In_Limited or Limited_Withs)
+                  if (In_Limited or else Limited_Withs)
                     and then Project_Stack.Last > 1
                   then
                      declare
                         Canonical_Path_Name : Path_Name_Type;
 
                      begin
-                        Name_Len := Resolved_Path'Length;
+                        Name_Len                    := Resolved_Path'Length;
                         Name_Buffer (1 .. Name_Len) := Resolved_Path;
                         Canonical_Case_File_Name (Name_Buffer (1 .. Name_Len));
                         Canonical_Path_Name := Name_Find;
@@ -1029,18 +1029,14 @@ package body GPR.Part is
 
                   if No (Withed_Project) then
                      Parse_Single_Project
-                       (In_Tree           => In_Tree,
-                        Project           => Withed_Project,
+                       (In_Tree => In_Tree, Project => Withed_Project,
                         Extends_All       => Extends_All,
                         Path_Name_Id      => Imported_Path_Name_Id,
-                        Extended          => False,
-                        From_Extended     => From_Extended,
-                        In_Limited        => In_Limited or Limited_Withs,
-                        Packages_To_Check => Packages_To_Check,
-                        Depth             => Depth,
+                        Extended => False, From_Extended => From_Extended,
+                        In_Limited        => In_Limited or else Limited_Withs,
+                        Packages_To_Check => Packages_To_Check, Depth => Depth,
                         Current_Dir       => Current_Dir,
-                        Is_Config_File    => Is_Config_File,
-                        Env               => Env);
+                        Is_Config_File    => Is_Config_File, Env => Env);
 
                   else
                      Extends_All := Is_Extending_All (Withed_Project, In_Tree);

--- a/gpr/src/gpr-util.adb
+++ b/gpr/src/gpr-util.adb
@@ -888,7 +888,7 @@ package body GPR.Util is
       No_Message     : Boolean        := False;
       Command        : String         := "") is
    begin
-      if Flush_Messages and not No_Message then
+      if Flush_Messages and then not No_Message then
          if Total_Errors_Detected /= 0 or else Warnings_Detected /= 0 then
             Err.Finalize;
          end if;
@@ -2015,7 +2015,7 @@ package body GPR.Util is
    begin
       --  Nothing to do if source record has already been fully initialized
 
-      if Source.Initialized and not Always then
+      if Source.Initialized and then not Always then
          return;
       end if;
 

--- a/gpr/src/gpr_build_util.adb
+++ b/gpr/src/gpr_build_util.adb
@@ -509,7 +509,7 @@ package body Gpr_Build_Util is
 
          Close (Mapping_FD, Status);
 
-         OK := OK and Status;
+         OK := OK and then Status;
       end if;
 
       --  If the creation of the mapping file was successful, we add the switch
@@ -2369,10 +2369,10 @@ package body Gpr_Build_Util is
               Has_Mains
                 or else (Root_Project.Library
                           and then Root_Project.Standalone_Library /= No);
-            Data.Need_Compilation := All_Phases or Option_Compile_Only;
-            Data.Need_Binding     := All_Phases or Option_Bind_Only;
-            Data.Need_Linking     := (All_Phases or Option_Link_Only)
-                                       and Has_Mains;
+            Data.Need_Compilation := All_Phases or else Option_Compile_Only;
+            Data.Need_Binding := All_Phases or else Option_Bind_Only;
+            Data.Need_Linking :=
+              (All_Phases or else Option_Link_Only) and then Has_Mains;
          end if;
 
          if Current_Verbosity = High then

--- a/src/gprbind.adb
+++ b/src/gprbind.adb
@@ -860,7 +860,7 @@ begin
    end if;
 
    if Return_Code /= 0 then
-      if Delete_Temp_Files and not Dash_O_File_Specified then
+      if Delete_Temp_Files and then not Dash_O_File_Specified then
          Delete_File (Get_Name_String (Objects_Path), Success);
       end if;
 

--- a/src/gprbuild-compile.adb
+++ b/src/gprbuild-compile.adb
@@ -1933,7 +1933,7 @@ package body Gprbuild.Compile is
             end if;
          end if;
 
-         if Compilation_OK and Dep_File_OK then
+         if Compilation_OK and then Dep_File_OK then
             Create (Dep_File, Dep_Path);
             Put (Dep_File, Object_Path.all);
             Put (Dep_File, ": ");
@@ -2143,7 +2143,7 @@ package body Gprbuild.Compile is
                Add_Option_Internal_Codepeer
                  (Value   => Get_Name_String (Nam_Nod.Name),
                   To      => Compilation_Options,
-                  Display => First or Opt.Verbose_Mode);
+                  Display => First or else Opt.Verbose_Mode);
                First := False;
             end if;
 

--- a/src/gprbuild-main.adb
+++ b/src/gprbuild-main.adb
@@ -236,22 +236,20 @@ procedure Gprbuild.Main is
             exit when Main_Id = No_Main_Info;
 
             Queue.Insert_Project_Sources
-              (Project        => Main_Id.Project,
-               Project_Tree   => Main_Id.Tree,
+              (Project        => Main_Id.Project, Project_Tree => Main_Id.Tree,
                Unique_Compile => Unique_Compile,
-               All_Projects =>
-                  not Unique_Compile
-               or else (Unique_Compile_All_Projects or Recursive));
+               All_Projects   =>
+                 not Unique_Compile
+                 or else (Unique_Compile_All_Projects or else Recursive));
          end loop;
 
       else
          Queue.Insert_Project_Sources
-           (Project        => Main_Project,
-            Project_Tree   => Project_Tree,
+           (Project        => Main_Project, Project_Tree => Project_Tree,
             Unique_Compile => Unique_Compile,
-            All_Projects =>
-               not Unique_Compile
-            or else (Unique_Compile_All_Projects or Recursive));
+            All_Projects   =>
+              not Unique_Compile
+              or else (Unique_Compile_All_Projects or else Recursive));
       end if;
    end Add_Mains_To_Queue;
 
@@ -1851,7 +1849,7 @@ procedure Gprbuild.Main is
 
          Opt.Link_Only := False;
 
-         if not Opt.Compile_Only and not Opt.Bind_Only then
+         if not Opt.Compile_Only and then not Opt.Bind_Only then
             Opt.Compile_Only := True;
             Opt.Bind_Only    := True;
          end if;
@@ -2642,7 +2640,7 @@ begin
       if No_Link then
          Opt.Link_Only := False;
 
-         if not Opt.Compile_Only and not Opt.Bind_Only then
+         if not Opt.Compile_Only and then not Opt.Bind_Only then
             Opt.Compile_Only := True;
             Opt.Bind_Only    := True;
          end if;
@@ -2791,7 +2789,7 @@ begin
          Slave_Env :=
            new String'(Aux.Compute_Slave_Env (Project_Tree, Slave_Env_Auto));
 
-         if Slave_Env_Auto and not Opt.Quiet_Output then
+         if Slave_Env_Auto and then not Opt.Quiet_Output then
             Put ("slave environment is ");
             Put (Slave_Env.all);
             New_Line;

--- a/src/gprbuild-post_compile.adb
+++ b/src/gprbuild-post_compile.adb
@@ -3746,9 +3746,8 @@ package body Gprbuild.Post_Compile is
               and then Is_Included_In_Global_Archive
                          (Source.Object, Source.Project)
             then
-               if Source.Project = For_Project
-                 or not Source.Project.Library
-                 or Config.Kind = File_Based
+               if Source.Project = For_Project or not Source.Project.Library or
+                 Config.Kind = File_Based
                then
                   Add_Dep (Get_Name_String (Source.Dep_Path));
                   Dep_Files := True;
@@ -3974,15 +3973,14 @@ package body Gprbuild.Post_Compile is
                --  no object file per se.
 
                if Bind_Object_TS = Osint.Invalid_Time
-                 and not Opt.CodePeer_Mode
+                 and then not Opt.CodePeer_Mode
                then
                   Binder_Driver_Needs_To_Be_Called := True;
 
                   if Opt.Verbosity_Level > Opt.Low then
                      Put_Line
                        ("      -> binder generated object " &
-                        Line (1 .. Last) &
-                        " does not exist");
+                        Line (1 .. Last) & " does not exist");
                   end if;
                end if;
             end if;

--- a/src/gprbuild.adb
+++ b/src/gprbuild.adb
@@ -132,9 +132,8 @@ package body Gprbuild is
          if Element.Value /= Empty_String then
 
             Add_Option
-              (Value       => Element.Value,
-               To          => To,
-               Display     => Display_All or First_Display,
+              (Value       => Element.Value, To => To,
+               Display     => Display_All or else First_Display,
                Simple_Name => Simple_Name);
             First_Display := False;
          end if;

--- a/src/gprclean-main.adb
+++ b/src/gprclean-main.adb
@@ -961,7 +961,7 @@ begin
    --  generated, gprclean will delete it if it was specified using
    --  --autoconf=.
 
-   Delete_Autoconf_File := Delete_Autoconf_File or Autoconf_Specified;
+   Delete_Autoconf_File := Delete_Autoconf_File or else Autoconf_Specified;
 
    if Configuration_Project_Path /= null then
       Free (Config_Project_File_Name);
@@ -993,7 +993,7 @@ begin
       Slave_Env :=
         new String'(Aux.Compute_Slave_Env (Project_Tree, Slave_Env_Auto));
 
-      if Slave_Env_Auto and not Opt.Quiet_Output then
+      if Slave_Env_Auto and then not Opt.Quiet_Output then
          Put_Line ("slave environment is " & Slave_Env.all);
       end if;
    end if;
@@ -1060,7 +1060,7 @@ begin
    --  In verbose mode, if Delete has not been called, indicate that
    --  no file needs to be deleted.
 
-   if Verbose_Mode and (not File_Deleted) then
+   if Verbose_Mode and then (not File_Deleted) then
       New_Line;
 
       if Do_Nothing then

--- a/src/gprinstall-install.adb
+++ b/src/gprinstall-install.adb
@@ -1426,7 +1426,7 @@ package body Gprinstall.Install is
                Pattern   => Get_Pattern,
                Process   => Copy_Entry'Access);
 
-            if Required and not Something_Copied then
+            if Required and then not Something_Copied then
                Rollback_Manifests;
                Fail_Program
                  (Project_Tree,
@@ -1474,7 +1474,7 @@ package body Gprinstall.Install is
 
          --  Copy library
 
-         if Copy (Library) and not Sources_Only then
+         if Copy (Library) and then not Sources_Only then
             if not Is_Static (Project)
               and then Project.Lib_Internal_Name /= No_Name
               and then Project.Library_Name /= Project.Lib_Internal_Name
@@ -1483,42 +1483,42 @@ package body Gprinstall.Install is
                   --  No support for version, do a simple copy
 
                   Copy_File
-                    (From          => Cat
-                       (Project.Library_Dir.Display_Name,
-                        Get_Library_Filename),
-                     To            => Lib_Dir,
-                     File          => Get_Name_String (Get_Library_Filename),
-                     Executable    => True,
-                     Extract_Debug => Side_Debug);
+                    (From =>
+                       Cat
+                         (Project.Library_Dir.Display_Name,
+                          Get_Library_Filename),
+                     To         => Lib_Dir,
+                     File       => Get_Name_String (Get_Library_Filename),
+                     Executable => True, Extract_Debug => Side_Debug);
 
                else
                   Copy_File
-                    (From          => Cat
-                       (Project.Library_Dir.Display_Name,
-                        File_Name_Type (Project.Lib_Internal_Name)),
-                     To            => Lib_Dir,
-                     File          =>
-                       Get_Name_String (Project.Lib_Internal_Name),
-                     Executable    => True,
-                     Extract_Debug => Side_Debug);
+                    (From =>
+                       Cat
+                         (Project.Library_Dir.Display_Name,
+                          File_Name_Type (Project.Lib_Internal_Name)),
+                     To         => Lib_Dir,
+                     File       => Get_Name_String (Project.Lib_Internal_Name),
+                     Executable => True, Extract_Debug => Side_Debug);
 
                   Copy_File
-                    (From     => Lib_Dir
-                                   & Get_Name_String (Get_Library_Filename),
+                    (From => Lib_Dir & Get_Name_String (Get_Library_Filename),
                      To       => Lib_Dir,
                      File     => Get_Name_String (Project.Lib_Internal_Name),
-                     From_Ver => Cat (Lib_Dir,
-                        Major_Id_Name
-                           (Get_Name_String (Get_Library_Filename),
-                            Get_Name_String (Project.Lib_Internal_Name))),
+                     From_Ver =>
+                       Cat
+                         (Lib_Dir,
+                          Major_Id_Name
+                            (Get_Name_String (Get_Library_Filename),
+                             Get_Name_String (Project.Lib_Internal_Name))),
                      Sym_Link => True);
                end if;
 
             else
                Copy_File
-                 (From          => Cat
-                    (Project.Library_Dir.Display_Name,
-                     Get_Library_Filename),
+                 (From =>
+                    Cat
+                      (Project.Library_Dir.Display_Name, Get_Library_Filename),
                   To            => Lib_Dir,
                   File          => Get_Name_String (Get_Library_Filename),
                   Executable    => not Is_Static (Project),
@@ -1534,30 +1534,29 @@ package body Gprinstall.Install is
                if Windows_Target then
                   if Lib_Dir /= Exec_Dir then
                      Copy_File
-                       (From          => Lib_Dir
-                        & Get_Name_String (Get_Library_Filename),
-                        To            => Exec_Dir,
-                        File          =>
-                          Get_Name_String (Get_Library_Filename),
-                        Executable    => True,
-                        Extract_Debug => False);
+                       (From =>
+                          Lib_Dir & Get_Name_String (Get_Library_Filename),
+                        To         => Exec_Dir,
+                        File       => Get_Name_String (Get_Library_Filename),
+                        Executable => True, Extract_Debug => False);
                   end if;
 
                elsif Link_Lib_Dir /= Lib_Dir then
                   if On_Windows then
                      Copy_File
-                       (From       => Lib_Dir
-                          & Get_Name_String (Get_Library_Filename),
-                        To         => Link_Lib_Dir,
-                        File       => Get_Name_String (Get_Library_Filename),
-                        Sym_Link   => False);
+                       (From =>
+                          Lib_Dir & Get_Name_String (Get_Library_Filename),
+                        To       => Link_Lib_Dir,
+                        File     => Get_Name_String (Get_Library_Filename),
+                        Sym_Link => False);
                   else
                      Copy_File
-                       (From       => Link_Lib_Dir
-                          & Get_Name_String (Get_Library_Filename),
-                        To         => Lib_Dir,
-                        File       => Get_Name_String (Get_Library_Filename),
-                        Sym_Link   => True);
+                       (From =>
+                          Link_Lib_Dir &
+                          Get_Name_String (Get_Library_Filename),
+                        To       => Lib_Dir,
+                        File     => Get_Name_String (Get_Library_Filename),
+                        Sym_Link => True);
                   end if;
                   --  Copy also the versioned library if any
 
@@ -1566,30 +1565,34 @@ package body Gprinstall.Install is
                   then
                      if On_Windows then
                         Copy_File
-                          (From       =>
-                             Lib_Dir
-                               & Get_Name_String (Project.Lib_Internal_Name),
-                           To         => Link_Lib_Dir,
-                           File       =>
+                          (From =>
+                             Lib_Dir &
                              Get_Name_String (Project.Lib_Internal_Name),
-                           From_Ver   => Cat (Link_Lib_Dir,
-                             Major_Id_Name
-                               (Get_Name_String (Get_Library_Filename),
-                                Get_Name_String (Project.Lib_Internal_Name))),
-                           Sym_Link   => False);
+                           To       => Link_Lib_Dir,
+                           File => Get_Name_String (Project.Lib_Internal_Name),
+                           From_Ver =>
+                             Cat
+                               (Link_Lib_Dir,
+                                Major_Id_Name
+                                  (Get_Name_String (Get_Library_Filename),
+                                   Get_Name_String
+                                     (Project.Lib_Internal_Name))),
+                           Sym_Link => False);
                      else
                         Copy_File
-                          (From       =>
-                             Link_Lib_Dir
-                               & Get_Name_String (Project.Lib_Internal_Name),
-                           To         => Lib_Dir,
-                           File       =>
+                          (From =>
+                             Link_Lib_Dir &
                              Get_Name_String (Project.Lib_Internal_Name),
-                           From_Ver   => Cat (Link_Lib_Dir,
-                             Major_Id_Name
-                               (Get_Name_String (Get_Library_Filename),
-                                Get_Name_String (Project.Lib_Internal_Name))),
-                           Sym_Link   => True);
+                           To       => Lib_Dir,
+                           File => Get_Name_String (Project.Lib_Internal_Name),
+                           From_Ver =>
+                             Cat
+                               (Link_Lib_Dir,
+                                Major_Id_Name
+                                  (Get_Name_String (Get_Library_Filename),
+                                   Get_Name_String
+                                     (Project.Lib_Internal_Name))),
+                           Sym_Link => True);
                      end if;
                   end if;
                end if;
@@ -1598,7 +1601,7 @@ package body Gprinstall.Install is
 
          --  Copy executable(s)
 
-         if Copy (Executable) and not Sources_Only then
+         if Copy (Executable) and then not Sources_Only then
             Mains.Reset;
 
             declare
@@ -1608,15 +1611,14 @@ package body Gprinstall.Install is
                   if M.Project in Project | Project.Extends then
                      declare
                         Bin : constant String :=
-                                Main_Binary (Name_Id (M.File));
+                          Main_Binary (Name_Id (M.File));
                      begin
                         Copy_File
-                          (From          =>
+                          (From =>
                              Get_Name_String
-                               (Project.Exec_Directory.Display_Name) & Bin,
-                           To            => Exec_Dir,
-                           File          => Bin,
-                           Executable    => True,
+                               (Project.Exec_Directory.Display_Name) &
+                             Bin,
+                           To => Exec_Dir, File => Bin, Executable => True,
                            Extract_Debug => Side_Debug);
                      end;
                   end if;
@@ -2852,16 +2854,16 @@ package body Gprinstall.Install is
             Line := Line & " is";
             Content.Append (-Line);
 
-            if Has_Sources (Project) or Project.Library then
+            if Has_Sources (Project) or else Project.Library then
                --  BUILD variable
 
                Content.Append
                  ("   type BUILD_KIND is (""" & Build_Name.all & """);");
 
-               Line := +Get_Build_Line
-                 (Vars    =>
-                    (if Build_Vars = null then "" else Build_Vars.all),
-                  Default => Build_Name.all);
+               Line :=
+                 +Get_Build_Line
+                   (Vars => (if Build_Vars = null then "" else Build_Vars.all),
+                    Default => Build_Name.all);
 
                Content.Append (-Line);
 
@@ -2889,9 +2891,8 @@ package body Gprinstall.Install is
 
                if Project.Library then
                   Content.Append
-                    ("   for Library_Name use """
-                     & Get_Name_String (Project.Library_Name)
-                     & """;");
+                    ("   for Library_Name use """ &
+                     Get_Name_String (Project.Library_Name) & """;");
 
                   --  Issue the Library_Version only if needed
 
@@ -2900,9 +2901,8 @@ package body Gprinstall.Install is
                     and then Project.Library_Name /= Project.Lib_Internal_Name
                   then
                      Content.Append
-                       ("   for Library_Version use """
-                        & Get_Name_String (Project.Lib_Internal_Name)
-                        & """;");
+                       ("   for Library_Version use """ &
+                        Get_Name_String (Project.Lib_Internal_Name) & """;");
                   end if;
                end if;
 
@@ -3144,9 +3144,8 @@ package body Gprinstall.Install is
 
       --  Skip non active project and externally built ones
 
-      Is_Project_To_Install := Active
-        and (Bring_Sources (Project)
-             or Project.Externally_Built);
+      Is_Project_To_Install :=
+        Active and (Bring_Sources (Project) or else Project.Externally_Built);
 
       --  If we have an aggregate project we just install separately all
       --  aggregated projects.
@@ -3186,7 +3185,7 @@ package body Gprinstall.Install is
                Put ("Skip");
             end if;
 
-            if Is_Project_To_Install or Opt.Verbose_Mode then
+            if Is_Project_To_Install or else Opt.Verbose_Mode then
                Put (" project ");
                Put (Get_Name_String (Project.Display_Name));
                if Build_Name.all /= "default" then
@@ -3194,11 +3193,11 @@ package body Gprinstall.Install is
                end if;
             end if;
 
-            if not Is_Project_To_Install and Opt.Verbose_Mode then
+            if not Is_Project_To_Install and then Opt.Verbose_Mode then
                Put (" (not active)");
             end if;
 
-            if Is_Project_To_Install or Opt.Verbose_Mode then
+            if Is_Project_To_Install or else Opt.Verbose_Mode then
                New_Line;
             end if;
          end if;

--- a/src/gprlib.adb
+++ b/src/gprlib.adb
@@ -566,7 +566,7 @@ procedure Gprlib is
                         --  Set Success to True only if the newly
                         --  created file has been correctly written.
 
-                        Success := Status and Actual_Len = Len + 3;
+                        Success := Status and then Actual_Len = Len + 3;
                      end if;
                   end if;
                end if;
@@ -2466,7 +2466,7 @@ begin
    --  files with no Ada sources (e.g. C only). Do not consider this as
    --  an error in this case.
 
-   if Object_Files.Is_Empty and not CodePeer_Mode then
+   if Object_Files.Is_Empty and then not CodePeer_Mode then
       Fail_Program (null, "no object files specified");
    end if;
 

--- a/src/gprls-main.adb
+++ b/src/gprls-main.adb
@@ -1008,7 +1008,7 @@ procedure Gprls.Main is
          end;
       end if;
 
-      if No_Files_In_Command_Line and not Closure then
+      if No_Files_In_Command_Line and then not Closure then
          --  Get all the compilable sources of the project
          declare
             Unit    : GPR.Unit_Index;
@@ -1043,8 +1043,7 @@ procedure Gprls.Main is
                      if not Subunit then
                         Add_File
                           (Get_Name_String (Unit.File_Names (Impl).Object),
-                           Tree,
-                           Source => Unit.File_Names (Impl));
+                           Tree, Source => Unit.File_Names (Impl));
                      end if;
                   end if;
 
@@ -1052,12 +1051,12 @@ procedure Gprls.Main is
                  and then not Unit.File_Names (Spec).Locally_Removed
                  and then
                --  We have a spec with no body. Check if it is for this project
+
                  (All_Projects
                   or else Unit.File_Names (Spec).Project = Project)
                then
                   Add_File
-                    (Get_Name_String (Unit.File_Names (Spec).Object),
-                     Tree,
+                    (Get_Name_String (Unit.File_Names (Spec).Object), Tree,
                      Source => Unit.File_Names (Spec));
                end if;
 
@@ -1092,7 +1091,8 @@ procedure Gprls.Main is
                      if All_Projects
                        or else
                          Ultimate_Extending_Project_Of
-                           (Unit.File_Names (Impl).Project) = Project
+                           (Unit.File_Names (Impl).Project) =
+                         Project
                      then
                         Subunit := False;
 
@@ -1119,12 +1119,11 @@ procedure Gprls.Main is
                               Canonical_Case_File_Name (Dep_Name);
 
                               if Dep_Name in File_Name | File_Name & ".ali"
-                                or else File_Name in Object_Name
-                                  | Get_Name_String
-                                    (Unit.File_Names (Impl).File)
-                                      | Get_Name_String
-                                        (Unit.File_Names (Impl)
-                                         .Display_File)
+                                or else File_Name in Object_Name |
+                                    Get_Name_String
+                                      (Unit.File_Names (Impl).File) |
+                                    Get_Name_String
+                                      (Unit.File_Names (Impl).Display_File)
                               then
                                  FN_Source.Source := Unit.File_Names (Impl);
                                  FN_Source.Tree   := Tree;
@@ -1137,8 +1136,9 @@ procedure Gprls.Main is
                   elsif Unit.File_Names (Spec) /= null
                     and then not Unit.File_Names (Spec).Locally_Removed
                     and then
-                  --  We have a spec with no body. Check if it is for this
-                  --  project.
+                     --  We have a spec with no body. Check if it is for this
+                     --  project.
+
                     (All_Projects
                      or else Unit.File_Names (Spec).Project = Project)
                   then
@@ -1152,11 +1152,10 @@ procedure Gprls.Main is
                         Canonical_Case_File_Name (Dep_Name);
 
                         if Dep_Name in File_Name | File_Name & ".ali"
-                          or else File_Name in Object_Name
-                            | Get_Name_String
-                              (Unit.File_Names (Spec).File)
-                                | Get_Name_String
-                                  (Unit.File_Names (Spec).Display_File)
+                          or else File_Name in Object_Name                  |
+                              Get_Name_String (Unit.File_Names (Spec).File) |
+                              Get_Name_String
+                                (Unit.File_Names (Spec).Display_File)
                         then
                            FN_Source.Source := Unit.File_Names (Spec);
                            FN_Source.Tree   := Tree;

--- a/src/gprslave.adb
+++ b/src/gprslave.adb
@@ -679,7 +679,9 @@ procedure Gprslave is
       Is_Debug : Boolean := False;
       Force    : Boolean := False) is
    begin
-      if Force or (Verbose and not Is_Debug) or (Debug and Is_Debug) then
+      if Force or else (Verbose and then not Is_Debug)
+        or else (Debug and then Is_Debug)
+      then
          IO.Message (Str, Is_Debug);
       end if;
    end Display;
@@ -690,7 +692,9 @@ procedure Gprslave is
       Is_Debug : Boolean := False;
       Force    : Boolean := False) is
    begin
-      if Force or (Verbose and not Is_Debug) or (Debug and Is_Debug) then
+      if Force or else (Verbose and then not Is_Debug)
+        or else (Debug and then Is_Debug)
+      then
          IO.Message (Builder, Str, Is_Debug);
       end if;
    end Display;


### PR DESCRIPTION
Dear Gprbuild developers,

According to [GnatCheck](https://docs.adacore.com/live/wave/asis/html/gnatcheck_rm/gnatcheck_rm/predefined_rules.html#non-short-circuit-operators), short circuit operators are preferred.
This pull requests removes all GnatCheck warning related to non short circuit operators.

Greetings,
   Pierre

Problem detected and solved by Rejuvenation-Ada crate
[![vote for Rejuvenation-Ada as The 2022 Ada Crate Of The Year](https://user-images.githubusercontent.com/18348654/191469254-1ca1f4a0-6242-43fa-94a2-f39f55817fdc.jpg)](https://github.com/AdaCore/Ada-SPARK-Crate-Of-The-Year/issues/15)
