### PR TITLE
prefer if expression over declare + overwrite

### DIFF
--- a/src/gprbind.adb
+++ b/src/gprbind.adb
@@ -633,17 +633,11 @@ begin
       Name_Len := 0;
 
       declare
-         Path_Of_Gnatbind : String_Access := GNATBIND;
+         Path_Of_Gnatbind : String_Access :=
+           (if Gnatbind_Path_Specified then FULL_GNATBIND else GNATBIND);
       begin
-
-         if Gnatbind_Path_Specified then
-            Path_Of_Gnatbind := FULL_GNATBIND;
-         end if;
-
          Finish_Program
-           (null,
-            Osint.E_Fatal,
-            "could not locate " & Path_Of_Gnatbind.all);
+           (null, Osint.E_Fatal, "could not locate " & Path_Of_Gnatbind.all);
       end;
 
    else


### PR DESCRIPTION
Dear Gprbuild developers,

Prefer if expression instead of declaring variable and overwriting it later.

Greetings,
   Pierre

P.S. Might want to add keyword constant to resulting declaration to signal that it is never changed anymore after initialization.

Problem detected and solved by Rejuvenation-Ada crate
[![vote for Rejuvenation-Ada as The 2022 Ada Crate Of The Year](https://user-images.githubusercontent.com/18348654/191469254-1ca1f4a0-6242-43fa-94a2-f39f55817fdc.jpg)](https://github.com/AdaCore/Ada-SPARK-Crate-Of-The-Year/issues/15)
