### PR TITLE
prefer if expressions

### DIFF
--- a/gpr/src/gpr-ali.adb
+++ b/gpr/src/gpr-ali.adb
@@ -1288,11 +1288,9 @@ package body GPR.ALI is
 
          Get_Name_String (Units.Table (Units.Last).Uname);
 
-         if Name_Buffer (Name_Len) = 'b' then
-            Units.Table (Units.Last).Utype := Is_Body_Only;
-         else
-            Units.Table (Units.Last).Utype := Is_Spec_Only;
-         end if;
+         Units.Table (Units.Last).Utype :=
+           (if Name_Buffer (Name_Len) = 'b' then Is_Body_Only
+            else Is_Spec_Only);
       end if;
 
       --  Ignore external version lines
@@ -1434,13 +1432,12 @@ package body GPR.ALI is
       if C = EOF then
          --  Check that gnatprove generated .ali files ended with right marker
 
-         if Opt.GnatProve_Mode
-           and then T (First_P .. Last_P) /= Spark_End_Marker
-         then
-            return No_ALI_Id;
-         end if;
-
-         return Id;
+         return
+           (if
+              Opt.GnatProve_Mode
+              and then T (First_P .. Last_P) /= Spark_End_Marker
+            then No_ALI_Id
+            else Id);
       end if;
 
       Check_Unknown_Line;

--- a/gpr/src/gpr-attr.adb
+++ b/gpr/src/gpr-attr.adb
@@ -75,11 +75,9 @@ package body GPR.Attr is
      (Attribute : Attribute_Node_Id) return Attribute_Default_Value
    is
    begin
-      if Attribute = Empty_Attribute then
-         return Empty_Value;
-      else
-         return Attrs.Table (Attribute.Value).Default;
-      end if;
+      return
+        (if Attribute = Empty_Attribute then Empty_Value
+         else Attrs.Table (Attribute.Value).Default);
    end Attribute_Default_Of;
 
    -----------------------
@@ -90,11 +88,9 @@ package body GPR.Attr is
      (Attribute : Attribute_Node_Id) return Attribute_Kind
    is
    begin
-      if Attribute = Empty_Attribute then
-         return Unknown;
-      else
-         return Attrs.Table (Attribute.Value).Attr_Kind;
-      end if;
+      return
+        (if Attribute = Empty_Attribute then Unknown
+         else Attrs.Table (Attribute.Value).Attr_Kind);
    end Attribute_Kind_Of;
 
    -----------------------
@@ -103,11 +99,9 @@ package body GPR.Attr is
 
    function Attribute_Name_Of (Attribute : Attribute_Node_Id) return Name_Id is
    begin
-      if Attribute = Empty_Attribute then
-         return No_Name;
-      else
-         return Attrs.Table (Attribute.Value).Name;
-      end if;
+      return
+        (if Attribute = Empty_Attribute then No_Name
+         else Attrs.Table (Attribute.Value).Name);
    end Attribute_Name_Of;
 
    --------------------------
@@ -213,14 +207,12 @@ package body GPR.Attr is
 
       function Attribute_Location return String is
       begin
-         if Current_Package = Empty_Pkg then
-            return "project level attributes";
-
-         else
-            return "attribute of package """
-              & Get_Name_String
-                  (Package_Attributes.Table (Current_Package).Name) & '"';
-         end if;
+         return
+           (if Current_Package = Empty_Pkg then "project level attributes"
+            else "attribute of package """ &
+              Get_Name_String
+                (Package_Attributes.Table (Current_Package).Name) &
+              '"');
       end Attribute_Location;
 
       -----------------
@@ -1427,11 +1419,9 @@ package body GPR.Attr is
       return Boolean
    is
    begin
-      if Attribute = Empty_Attribute then
-         return False;
-      else
-         return Attrs.Table (Attribute.Value).Config_Concat;
-      end if;
+      return
+        (Attribute /= Empty_Attribute)
+        and then Attrs.Table (Attribute.Value).Config_Concat;
    end Is_Config_Concatenable;
 
    ------------------
@@ -1451,11 +1441,9 @@ package body GPR.Attr is
      (After : Attribute_Node_Id) return Attribute_Node_Id
    is
    begin
-      if After = Empty_Attribute then
-         return Empty_Attribute;
-      else
-         return (Value => Attrs.Table (After.Value).Next);
-      end if;
+      return
+        (if After = Empty_Attribute then Empty_Attribute
+         else (Value => Attrs.Table (After.Value).Next));
    end Next_Attribute;
 
    -----------------------
@@ -1464,22 +1452,18 @@ package body GPR.Attr is
 
    function Optional_Index_Of (Attribute : Attribute_Node_Id) return Boolean is
    begin
-      if Attribute = Empty_Attribute then
-         return False;
-      else
-         return Attrs.Table (Attribute.Value).Optional_Index;
-      end if;
+      return
+        (Attribute /= Empty_Attribute)
+        and then Attrs.Table (Attribute.Value).Optional_Index;
    end Optional_Index_Of;
 
    function Others_Allowed_For
      (Attribute : Attribute_Node_Id) return Boolean
    is
    begin
-      if Attribute = Empty_Attribute then
-         return False;
-      else
-         return Attrs.Table (Attribute.Value).Others_Allowed;
-      end if;
+      return
+        (Attribute /= Empty_Attribute)
+        and then Attrs.Table (Attribute.Value).Others_Allowed;
    end Others_Allowed_For;
 
    -----------------------
@@ -1499,11 +1483,9 @@ package body GPR.Attr is
    begin
       for Index in Package_Attributes.First .. Package_Attributes.Last loop
          if Package_Attributes.Table (Index).Name = Name then
-            if Package_Attributes.Table (Index).Known then
-               return (Value => Index);
-            else
-               return Unknown_Package;
-            end if;
+            return
+              (if Package_Attributes.Table (Index).Known then (Value => Index)
+               else Unknown_Package);
          end if;
       end loop;
 
@@ -1810,11 +1792,9 @@ package body GPR.Attr is
      (Attribute : Attribute_Node_Id) return Variable_Kind
    is
    begin
-      if Attribute = Empty_Attribute then
-         return Undefined;
-      else
-         return Attrs.Table (Attribute.Value).Var_Kind;
-      end if;
+      return
+        (if Attribute = Empty_Attribute then Undefined
+         else Attrs.Table (Attribute.Value).Var_Kind);
    end Variable_Kind_Of;
 
    ------------------------
@@ -1825,12 +1805,10 @@ package body GPR.Attr is
      (Pkg : Package_Node_Id) return Attribute_Node_Id
    is
    begin
-      if Pkg = Empty_Package or else Pkg = Unknown_Package then
-         return Empty_Attribute;
-      else
-         return
-           (Value => Package_Attributes.Table (Pkg.Value).First_Attribute);
-      end if;
+      return
+        (if Pkg = Empty_Package or else Pkg = Unknown_Package then
+           Empty_Attribute
+         else (Value => Package_Attributes.Table (Pkg.Value).First_Attribute));
    end First_Attribute_Of;
 
    ----------------------
@@ -1839,11 +1817,9 @@ package body GPR.Attr is
 
    function Is_Package_Known (Pkg : Package_Node_Id) return Boolean is
    begin
-      if Pkg = Empty_Package or else Pkg = Unknown_Package then
-         return False;
-      else
-         return Package_Attributes.Table (Pkg.Value).Known;
-      end if;
+      return
+        not (Pkg = Empty_Package or else Pkg = Unknown_Package)
+        and then Package_Attributes.Table (Pkg.Value).Known;
    end Is_Package_Known;
 
 end GPR.Attr;

--- a/gpr/src/gpr-compilation-process.adb
+++ b/gpr/src/gpr-compilation-process.adb
@@ -150,12 +150,7 @@ package body GPR.Compilation.Process is
 
    function Get_Slave_For (Pid : Id) return String is
    begin
-      if Pid.Kind = Local then
-         return "";
-
-      else
-         return Results.Get_Slave_For (Pid);
-      end if;
+      return (if Pid.Kind = Local then "" else Results.Get_Slave_For (Pid));
    end Get_Slave_For;
 
    ----------
@@ -165,11 +160,10 @@ package body GPR.Compilation.Process is
    function Hash (Process : Id) return Header_Num is
       Modulo : constant Integer := Integer (Header_Num'Last) + 1;
    begin
-      if Process.Kind = Local then
-         return Header_Num (Pid_To_Integer (Process.Pid) mod Modulo);
-      else
-         return Header_Num (Process.R_Pid mod Remote_Id (Modulo));
-      end if;
+      return
+        (if Process.Kind = Local then
+           Header_Num (Pid_To_Integer (Process.Pid) mod Modulo)
+         else Header_Num (Process.R_Pid mod Remote_Id (Modulo)));
    end Hash;
 
    ------------------------
@@ -234,11 +228,9 @@ package body GPR.Compilation.Process is
          use type Failures_Slave_Set.Cursor;
          Pos : constant Failures_Slave_Set.Cursor := Failed_Proc.Find (Pid);
       begin
-         if Pos = Failures_Slave_Set.No_Element then
-            return "";
-         else
-            return Failures_Slave_Set.Element (Pos);
-         end if;
+         return
+           (if Pos = Failures_Slave_Set.No_Element then ""
+            else Failures_Slave_Set.Element (Pos));
       end Get_Slave_For;
 
       ---------------------------

--- a/gpr/src/gpr-compilation-protocol.adb
+++ b/gpr/src/gpr-compilation-protocol.adb
@@ -467,18 +467,15 @@ package body GPR.Compilation.Protocol is
          Timestamp    := Time_Stamp_Type (Line.Args (5).all);
          Version      := To_Unbounded_String (Line.Args (6).all);
 
-         if Line.Args'Length > 6 then
-            Hash := To_Unbounded_String (Line.Args (7).all);
-         else
-            Hash := Null_Unbounded_String;
-         end if;
+         Hash :=
+           (if Line.Args'Length > 6 then
+              To_Unbounded_String (Line.Args (7).all)
+            else Null_Unbounded_String);
 
-         if Line.Args'Length > 7 then
-            Included_Artifact_Patterns :=
-              To_Unbounded_String (Line.Args (8).all);
-         else
-            Included_Artifact_Patterns := Null_Unbounded_String;
-         end if;
+         Included_Artifact_Patterns :=
+           (if Line.Args'Length > 7 then
+              To_Unbounded_String (Line.Args (8).all)
+            else Null_Unbounded_String);
 
       elsif Line.Cmd = PG then
          Is_Ping := True;
@@ -1244,15 +1241,11 @@ package body GPR.Compilation.Protocol is
    is
       P : constant Natural := Index (Str, To_String (Channel.WD_To));
    begin
-      if P = 0 then
-         return Str;
-
-      else
-         --  Make sure we translate the filename to native directory seprator
-         return To_Native_Directory_Separator
-           (To_String (Channel.WD_From)
-            & Str (P + Length (Channel.WD_To) .. Str'Last));
-      end if;
+      return
+        (if P = 0 then Str
+         else To_Native_Directory_Separator
+             (To_String (Channel.WD_From) &
+              Str (P + Length (Channel.WD_To) .. Str'Last)));
    end Translate_Receive;
 
    --------------------
@@ -1264,12 +1257,10 @@ package body GPR.Compilation.Protocol is
    is
       P : constant Natural := Index (Str, To_String (Channel.WD_From));
    begin
-      if P = 0 then
-         return Str;
-      else
-         return To_String (Channel.WD_To)
-           & Str (P + Length (Channel.WD_From) .. Str'Last);
-      end if;
+      return
+        (if P = 0 then Str
+         else To_String (Channel.WD_To) &
+           Str (P + Length (Channel.WD_From) .. Str'Last));
    end Translate_Send;
 
 end GPR.Compilation.Protocol;

--- a/gpr/src/gpr-compilation-slave.adb
+++ b/gpr/src/gpr-compilation-slave.adb
@@ -143,11 +143,7 @@ package body GPR.Compilation.Slave is
    function Channel (Host : String) return Protocol.Communication_Channel is
       S : constant Slave := Slaves.Find (Host);
    begin
-      if S = No_Slave then
-         return No_Channel;
-      else
-         return S.Channel;
-      end if;
+      return (if S = No_Slave then No_Channel else S.Channel);
    end Channel;
 
    ----------------------------
@@ -538,14 +534,13 @@ package body GPR.Compilation.Slave is
                               RD : constant String :=
                                      Get_Name_String (V.Value.Value);
                            begin
-                              if Is_Absolute_Path (RD) then
-                                 Root_Dir := To_Unbounded_String (RD);
-                              else
-                                 Root_Dir := To_Unbounded_String
-                                   (Normalize_Pathname
-                                      (To_String (Root_Dir)
-                                       & Directory_Separator & RD));
-                              end if;
+                              Root_Dir :=
+                                (if Is_Absolute_Path (RD) then
+                                   To_Unbounded_String (RD)
+                                 else To_Unbounded_String
+                                     (Normalize_Pathname
+                                        (To_String (Root_Dir) &
+                                         Directory_Separator & RD)));
 
                               if not Exists (To_String (Root_Dir))
                                 or else not Is_Directory (To_String (Root_Dir))
@@ -835,11 +830,9 @@ package body GPR.Compilation.Slave is
          S        : constant Slave := (Sock => Socket, others => <>);
          Position : constant Slave_S.Cursor := Pool.Find (S);
       begin
-         if Slave_S.Has_Element (Position) then
-            return Slave_S.Element (Position);
-         else
-            return No_Slave;
-         end if;
+         return
+           (if Slave_S.Has_Element (Position) then Slave_S.Element (Position)
+            else No_Slave);
       end Find;
 
       function Find (Host : String) return Slave is

--- a/gpr/src/gpr-compilation-sync.adb
+++ b/gpr/src/gpr-compilation-sync.adb
@@ -221,18 +221,10 @@ package body GPR.Compilation.Sync is
 
                else
                   if I_Regexp'Length = 0 then
-                     if Match (S_Name, E_Regexp) then
-                        Is_File := False;
-                     else
-                        Is_File := True;
-                     end if;
+                     Is_File := not Match (S_Name, E_Regexp);
 
                   else
-                     if Match (S_Name, I_Regexp) then
-                        Is_File := True;
-                     else
-                        Is_File := False;
-                     end if;
+                     Is_File := Match (S_Name, I_Regexp);
                   end if;
 
                   if Is_File then

--- a/gpr/src/gpr-conf.adb
+++ b/gpr/src/gpr-conf.adb
@@ -570,11 +570,10 @@ package body GPR.Conf is
    is
       C : constant Language_Maps.Cursor := Self.Find (Lang);
    begin
-      if Language_Maps.Has_Element (C) then
-         return Get_Name_String (Language_Maps.Element (C));
-      else
-         return "";
-      end if;
+      return
+        (if Language_Maps.Has_Element (C) then
+           Get_Name_String (Language_Maps.Element (C))
+         else "");
    end Get_Element_Or_Empty;
 
    --------------------------------------
@@ -840,14 +839,11 @@ package body GPR.Conf is
 
       begin
          if Selected_Target'Length /= 0 then
-            if Ada_RTS /= "" then
-               return
-                 Selected_Target.all & '-' &
-                 Ada_RTS & Config_Project_File_Extension;
-            else
-               return
-                 Selected_Target.all & Config_Project_File_Extension;
-            end if;
+            return
+              (if Ada_RTS /= "" then
+                 Selected_Target.all & '-' & Ada_RTS &
+                 Config_Project_File_Extension
+               else Selected_Target.all & Config_Project_File_Extension);
 
          elsif Ada_RTS /= "" then
             return Ada_RTS & Config_Project_File_Extension;
@@ -861,11 +857,7 @@ package body GPR.Conf is
             begin
                Free (Tmp);
 
-               if T'Length = 0 then
-                  return Default_Config_Name;
-               else
-                  return T;
-               end if;
+               return (if T'Length = 0 then Default_Config_Name else T);
             end;
          end if;
       end Default_File_Name;
@@ -1052,11 +1044,10 @@ package body GPR.Conf is
                Arg_Last := 4;
 
             elsif Normalized_Hostname /= "" then
-               if At_Least_One_Compiler_Command then
-                  Args (4) := new String'("--target=all");
-               else
-                  Args (4) := new String'("--target=" & Normalized_Hostname);
-               end if;
+               Args (4) :=
+                 (if At_Least_One_Compiler_Command then
+                    new String'("--target=all")
+                  else new String'("--target=" & Normalized_Hostname));
 
                Arg_Last := 4;
             end if;
@@ -1072,11 +1063,9 @@ package body GPR.Conf is
             end if;
 
             if Opt.Verbose_Mode and then Opt.Verbosity_Level > Opt.Low then
-               if Opt.Verbosity_Level = Opt.High then
-                  Write_Str (Gprconfig_Path.all);
-               else
-                  Write_Str (Gprconfig_Name);
-               end if;
+               Write_Str
+                 ((if Opt.Verbosity_Level = Opt.High then Gprconfig_Path.all
+                   else Gprconfig_Name));
 
                for J in 1 .. Arg_Last loop
                   Write_Char (' ');
@@ -1390,15 +1379,14 @@ package body GPR.Conf is
                           Get_Name_String (Variable.Value);
 
                      begin
-                        if Is_Absolute_Path (Compiler_Command) then
-                           Result (Count) := new String'
-                             (Config_Common
-                              & Containing_Directory (Compiler_Command) & ","
-                              & Simple_Name (Compiler_Command));
-                        else
-                           Result (Count) := new String'
-                             (Config_Common & ',' & Compiler_Command);
-                        end if;
+                        Result (Count) :=
+                          (if Is_Absolute_Path (Compiler_Command) then
+                             new String'
+                               (Config_Common &
+                                Containing_Directory (Compiler_Command) & "," &
+                                Simple_Name (Compiler_Command))
+                           else new String'
+                               (Config_Common & ',' & Compiler_Command));
                      end;
                   end if;
                end;
@@ -1677,14 +1665,13 @@ package body GPR.Conf is
    function Locate_Config_File (Name : String) return String_Access is
       Prefix_Path : constant String := Executable_Prefix_Path;
    begin
-      if Prefix_Path'Length /= 0 then
-         return Locate_Regular_File
-           (Name,
-            "." & Path_Separator &
-            Prefix_Path & "share" & Directory_Separator & "gpr");
-      else
-         return Locate_Regular_File (Name, ".");
-      end if;
+      return
+        (if Prefix_Path'Length /= 0 then
+           Locate_Regular_File
+             (Name,
+              "." & Path_Separator & Prefix_Path & "share" &
+              Directory_Separator & "gpr")
+         else Locate_Regular_File (Name, "."));
    end Locate_Config_File;
 
    ------------------------------------
@@ -2615,18 +2602,13 @@ package body GPR.Conf is
 
                   begin
                      if Runtime'Length > 0 then
-                        if Is_Absolute_Path (Runtime) then
-                           Root := new String'(Runtime);
-
-                        else
-                           Root :=
-                             new String'
-                               (Prefix.all &
-                                  Directory_Separator &
-                                  Opt.Target_Value.all &
-                                  Directory_Separator &
-                                  Runtime);
-                        end if;
+                        Root :=
+                          (if Is_Absolute_Path (Runtime) then
+                             new String'(Runtime)
+                           else new String'
+                               (Prefix.all & Directory_Separator &
+                                Opt.Target_Value.all & Directory_Separator &
+                                Runtime));
 
                         Runtime_Root := Compiler_Root.Runtimes;
                         while Runtime_Root /= null loop

--- a/gpr/src/gpr-env.adb
+++ b/gpr/src/gpr-env.adb
@@ -634,11 +634,9 @@ package body GPR.Env is
          Put ("pragma Source_File_Name_Project (");
          Put (Get_Name_String (Source.Unit.Name));
 
-         if Source.Kind = Spec then
-            Put (", Spec_File_Name => """);
-         else
-            Put (", Body_File_Name => """);
-         end if;
+         Put
+           ((if Source.Kind = Spec then ", Spec_File_Name => """
+             else ", Body_File_Name => """));
 
          Put (Get_Name_String (Source.File));
          Put ("""");
@@ -864,11 +862,8 @@ package body GPR.Env is
 
                Add_Char_To_Name_Buffer ('%');
 
-               if Source.Kind = Spec then
-                  Add_Char_To_Name_Buffer ('s');
-               else
-                  Add_Char_To_Name_Buffer ('b');
-               end if;
+               Add_Char_To_Name_Buffer
+                 ((if Source.Kind = Spec then 's' else 'b'));
 
                Unit := Name_Find;
 
@@ -1162,13 +1157,10 @@ package body GPR.Env is
                            Write_Line ("   OK");
                         end if;
 
-                        if Full_Path then
-                           return Get_Name_String
-                             (Unit.File_Names (Impl).Path.Name);
-
-                        else
-                           return Get_Name_String (Current_Name);
-                        end if;
+                        return
+                          (if Full_Path then
+                             Get_Name_String (Unit.File_Names (Impl).Path.Name)
+                           else Get_Name_String (Current_Name));
 
                         --  If it has the name of the extended body name,
                         --  return the extended body name
@@ -1178,13 +1170,10 @@ package body GPR.Env is
                            Write_Line ("   OK");
                         end if;
 
-                        if Full_Path then
-                           return Get_Name_String
-                             (Unit.File_Names (Impl).Path.Name);
-
-                        else
-                           return Get_Name_String (The_Body_Name);
-                        end if;
+                        return
+                          (if Full_Path then
+                             Get_Name_String (Unit.File_Names (Impl).Path.Name)
+                           else Get_Name_String (The_Body_Name));
 
                      else
                         if Current_Verbosity = High then
@@ -1226,12 +1215,10 @@ package body GPR.Env is
                            Write_Line ("   OK");
                         end if;
 
-                        if Full_Path then
-                           return Get_Name_String
-                             (Unit.File_Names (Spec).Path.Name);
-                        else
-                           return Get_Name_String (Current_Name);
-                        end if;
+                        return
+                          (if Full_Path then
+                             Get_Name_String (Unit.File_Names (Spec).Path.Name)
+                           else Get_Name_String (Current_Name));
 
                         --  If it has the same name as the extended spec name,
                         --  return the extended spec name.
@@ -1241,12 +1228,10 @@ package body GPR.Env is
                            Write_Line ("   OK");
                         end if;
 
-                        if Full_Path then
-                           return Get_Name_String
-                             (Unit.File_Names (Spec).Path.Name);
-                        else
-                           return Get_Name_String (The_Spec_Name);
-                        end if;
+                        return
+                          (if Full_Path then
+                             Get_Name_String (Unit.File_Names (Spec).Path.Name)
+                           else Get_Name_String (The_Spec_Name));
 
                      else
                         if Current_Verbosity = High then
@@ -2155,11 +2140,7 @@ package body GPR.Env is
       end if;
 
       if Is_Absolute_Path (Path) then
-         if Check_Filename (Path) then
-            return new String'(Path);
-         else
-            return null;
-         end if;
+         return (if Check_Filename (Path) then new String'(Path) else null);
       end if;
 
       CF := Self.Found.Find (Path);

--- a/gpr/src/gpr-err-scanner.adb
+++ b/gpr/src/gpr-err-scanner.adb
@@ -765,11 +765,9 @@ package body Scanner is
                Scan_Integer;
             end if;
 
-            if Exponent_Is_Negative then
-               Scale := Scale - Int_Value;
-            else
-               Scale := Scale + Int_Value;
-            end if;
+            Scale :=
+              (if Exponent_Is_Negative then Scale - Int_Value
+               else Scale + Int_Value);
          end if;
 
          --  Case of real literal to be returned
@@ -782,16 +780,7 @@ package body Scanner is
          else
             Token := Tok_Integer_Literal;
 
-            if Scale = 0 then
-               Int_Literal_Value := Num_Value;
-
-            --  Avoid doing possibly expensive calculations in cases like
-            --  parsing 163E800_000# when semantics will not be done anyway.
-            --  This is especially useful when parsing garbled input.
-
-            else
-               Int_Literal_Value := 0;
-            end if;
+            Int_Literal_Value := (if Scale = 0 then Num_Value else 0);
          end if;
 
          if Checksum_Accumulate_Token_Checksum then
@@ -2226,11 +2215,9 @@ package body Scanner is
       --  we allow brackets encoding regardless of the standard encoding
       --  method being used, but otherwise we use this standard method.
 
-      if Chr = '[' then
-         C := Char_Code (WC_In (Chr, WCEM_Brackets));
-      else
-         C := Char_Code (WC_In (Chr, Wide_Character_Encoding_Method));
-      end if;
+      C :=
+        (if Chr = '[' then Char_Code (WC_In (Chr, WCEM_Brackets))
+         else Char_Code (WC_In (Chr, Wide_Character_Encoding_Method)));
 
       Err := False;
 
@@ -2341,11 +2328,7 @@ package body Scanner is
 
    begin
       if Chr = CR then
-         if Source (P + 1) = LF then
-            P := P + 2;
-         else
-            P := P + 1;
-         end if;
+         P := P + (if Source (P + 1) = LF then 2 else 1);
 
       elsif Chr = LF then
          P := P + 1;

--- a/gpr/src/gpr-err.adb
+++ b/gpr/src/gpr-err.adb
@@ -253,11 +253,8 @@ package body GPR.Err is
 
       procedure Write_File_Name (Name : File_Name_Type) is
       begin
-         if Name = No_File then
-            Write_Str ("(null)");
-         else
-            Write_Str (Get_Name_String (Name));
-         end if;
+         Write_Str
+           ((if Name = No_File then "(null)" else Get_Name_String (Name)));
       end Write_File_Name;
 
    begin
@@ -287,11 +284,10 @@ package body GPR.Err is
 
          while E /= No_Error_Msg loop
             if not Errors.Table (E).Deleted then
-               if Full_Path_Name_For_Brief_Errors then
-                  Write_File_Name (Full_Ref_Name (Errors.Table (E).Sfile));
-               else
-                  Write_File_Name (Reference_Name (Errors.Table (E).Sfile));
-               end if;
+               Write_File_Name
+                 ((if Full_Path_Name_For_Brief_Errors then
+                     Full_Ref_Name (Errors.Table (E).Sfile)
+                   else Reference_Name (Errors.Table (E).Sfile)));
 
                Write_Char (':');
                Write_Int (Int (Errors.Table (E).Line));
@@ -364,11 +360,9 @@ package body GPR.Err is
          Write_Str (" ");
          Write_Int (Num_Source_Lines (Main_Source_File));
 
-         if Num_Source_Lines (Main_Source_File) = 1 then
-            Write_Str (" line: ");
-         else
-            Write_Str (" lines: ");
-         end if;
+         Write_Str
+           ((if Num_Source_Lines (Main_Source_File) = 1 then " line: "
+             else " lines: "));
 
          if Total_Errors_Detected = 0 then
             Write_Str ("No errors");

--- a/gpr/src/gpr-erroutc.adb
+++ b/gpr/src/gpr-erroutc.adb
@@ -358,13 +358,12 @@ package body GPR.Erroutc is
             --  than one error message occurs at the same flag position).
 
             if P = Errors.Table (T).Sptr then
-               if (Flag_Num = 1 and then not Mult_Flags)
-                 or else Flag_Num > 9
-               then
-                  Write_Char ('|');
-               else
-                  Write_Char (Character'Val (Character'Pos ('0') + Flag_Num));
-               end if;
+               Write_Char
+                 ((if
+                     (Flag_Num = 1 and then not Mult_Flags)
+                     or else Flag_Num > 9
+                   then '|'
+                   else Character'Val (Character'Pos ('0') + Flag_Num)));
 
                --  Skip past the corresponding source text character
 
@@ -438,11 +437,7 @@ package body GPR.Erroutc is
             M := M / 10;
 
             if D = 0 then
-               if Z then
-                  C := '0';
-               else
-                  C := ' ';
-               end if;
+               C := (if Z then '0' else ' ');
             else
                Z := True;
                C := Character'Val (D + 48);

--- a/gpr/src/gpr-knowledge.adb
+++ b/gpr/src/gpr-knowledge.adb
@@ -339,11 +339,7 @@ package body GPR.Knowledge is
    is
       Attr : constant Node := Get_Named_Item (Attributes (N), Attribute);
    begin
-      if Attr = null then
-         return Default;
-      else
-         return Node_Value (Attr);
-      end if;
+      return (if Attr = null then Default else Node_Value (Attr));
    end Get_Attribute;
 
    --------------------------
@@ -414,11 +410,7 @@ package body GPR.Knowledge is
          return False;
 
       else
-         if B = Windows_Pattern then
-            return True;
-         else
-            return False;
-         end if;
+         return B = Windows_Pattern;
       end if;
    end Is_Windows_Executable;
 
@@ -464,14 +456,12 @@ package body GPR.Knowledge is
 
    function Name_As_Directory (Dir : String) return String is
    begin
-      if Dir = ""
-        or else Dir (Dir'Last) = Directory_Separator
-        or else Dir (Dir'Last) = '/'
-      then
-         return Dir;
-      else
-         return Dir & Directory_Separator;
-      end if;
+      return
+        (if
+           Dir = "" or else Dir (Dir'Last) = Directory_Separator
+           or else Dir (Dir'Last) = '/'
+         then Dir
+         else Dir & Directory_Separator);
    end Name_As_Directory;
 
    ----------------------------------
@@ -742,13 +732,11 @@ package body GPR.Knowledge is
                            Compiler.Prefix_Index := -1;
                      end;
 
-                     if not Ends_With (Val, Exec_Suffix.all) then
-                        Compiler.Executable_Re := new Pattern_Matcher'
-                          (Compile ("^" & Val & Exec_Suffix.all & "$"));
-                     else
-                        Compiler.Executable_Re := new Pattern_Matcher'
-                          (Compile ("^" & Val & "$"));
-                     end if;
+                     Compiler.Executable_Re :=
+                       (if Ends_With (Val, Exec_Suffix.all) then
+                          new Pattern_Matcher'(Compile ("^" & Val & "$"))
+                        else new Pattern_Matcher'
+                            (Compile ("^" & Val & Exec_Suffix.all & "$")));
                      Base.Check_Executable_Regexp := True;
                   end if;
 
@@ -1689,11 +1677,8 @@ package body GPR.Knowledge is
         or else Path_To_Check = "/"
         or else Path_To_Check = "" & Directory_Separator
       then
-         if Group = -1 then
-            Val := Value_If_Match;
-         else
-            Val := Get_String (Group_Match);
-         end if;
+         Val :=
+           (if Group = -1 then Value_If_Match else Get_String (Group_Match));
 
          if Contents /= null
            and then Is_Regular_File (Current_Dir)
@@ -1979,13 +1964,11 @@ package body GPR.Knowledge is
                   Extracted_From := Node.Var_Name;
 
                when Value_Constant =>
-                  if Node.Value = No_Name then
-                     Tmp_Result := Null_Unbounded_String;
-                  else
-                     Tmp_Result := To_Unbounded_String
-                       (Substitute_Variables_In_Compiler_Description
-                          (Get_Name_String (Node.Value), Comp));
-                  end if;
+                  Tmp_Result :=
+                    (if Node.Value = No_Name then Null_Unbounded_String
+                     else To_Unbounded_String
+                         (Substitute_Variables_In_Compiler_Description
+                            (Get_Name_String (Node.Value), Comp)));
                   From_Static := True;
                   Put_Verbose
                     (Attribute & ": constant := " & To_String (Tmp_Result));
@@ -2142,11 +2125,9 @@ package body GPR.Knowledge is
                      C      : String_Lists.Cursor;
                      Filter : Name_Id;
                   begin
-                     if Node.Typ = Value_Filter then
-                        Filter := Node.Filter;
-                     else
-                        Filter := No_Name;
-                     end if;
+                     Filter :=
+                       (if Node.Typ = Value_Filter then Node.Filter
+                        else No_Name);
 
                      --  When an external value is defined as a static string,
                      --  the only valid separator is ','. When computed
@@ -2603,14 +2584,11 @@ package body GPR.Knowledge is
       function Runtime_Or_Empty return String is
       begin
          if Comp.Runtime /= No_Name then
-            if Comp.Alt_Runtime = No_Name then
-               return " (" & Get_Name_String (Comp.Runtime) & " runtime)";
-            else
-               return
-                 " (" & Get_Name_String (Comp.Runtime) &
-                 " [" & Get_Name_String (Comp.Alt_Runtime) &
-                 "] runtime)";
-            end if;
+            return
+              (if Comp.Alt_Runtime = No_Name then
+                 " (" & Get_Name_String (Comp.Runtime) & " runtime)"
+               else " (" & Get_Name_String (Comp.Runtime) & " [" &
+                 Get_Name_String (Comp.Alt_Runtime) & "] runtime)");
          else
             return "";
          end if;
@@ -2641,11 +2619,9 @@ package body GPR.Knowledge is
 
       function Target return String is
       begin
-         if Show_Target then
-            return " on " & Get_Name_String (Comp.Target);
-         else
-            return "";
-         end if;
+         return
+           (if Show_Target then " on " & Get_Name_String (Comp.Target)
+            else "");
       end Target;
 
    begin
@@ -2759,11 +2735,7 @@ package body GPR.Knowledge is
 
       function Executable_Pattern return String is
       begin
-         if On_Windows then
-            return "*.{exe,bat,cmd}";
-         else
-            return "";
-         end if;
+         return (if On_Windows then "*.{exe,bat,cmd}" else "");
       end Executable_Pattern;
 
       C      : CDM.Cursor;
@@ -3810,15 +3782,14 @@ package body GPR.Knowledge is
          Last := Last - 1;
       end if;
 
-      if Last > 6 and then
-        Name (Last - 5 .. Last) = "adalib" and then
-        (Name (Last - 6) = Directory_Separator or else
-         Name (Last - 6) = '/')
-      then
-         Last := Last - 6;
-      else
-         Last := Name'Last;
-      end if;
+      Last :=
+        (if
+           Last > 6 and then Name (Last - 5 .. Last) = "adalib"
+           and then
+           (Name (Last - 6) = Directory_Separator
+            or else Name (Last - 6) = '/')
+         then Last - 6
+         else Name'Last);
 
       Name_Len := Last;
       Name_Buffer (1 .. Last) := Name (1 .. Last);
@@ -4363,11 +4334,7 @@ package body GPR.Knowledge is
       function Compare (Name1, Name2 : Name_Id) return Compare_Type is
       begin
          if Name1 = No_Name then
-            if Name2 = No_Name then
-               return Equal;
-            else
-               return Before;
-            end if;
+            return (if Name2 = No_Name then Equal else Before);
 
          elsif Name2 = No_Name then
             return After;
@@ -4667,21 +4634,10 @@ package body GPR.Knowledge is
                               Idx : constant Natural := Index (N1, "gnatmake");
 
                            begin
-                              if LC = "ada" and then Idx /= 0 then
-                                 --  For Ada, gnatmake was previously used
-                                 --  to detect a GNAT compiler. However, as
-                                 --  gnatmake may not be present in all the
-                                 --  GNAT distributions, gnatls is now used.
-                                 --  For upward compatibility, replace gnatmake
-                                 --  with gnatls, so that a GNAT compiler may
-                                 --  be decteted.
-
-                                 return
-                                   Replace_Slice (N1, Idx, Idx + 7, "gnatls");
-
-                              else
-                                 return N1;
-                              end if;
+                              return
+                                (if LC = "ada" and then Idx /= 0 then
+                                   Replace_Slice (N1, Idx, Idx + 7, "gnatls")
+                                 else N1);
                            end Name;
 
                         begin
@@ -4840,12 +4796,7 @@ package body GPR.Knowledge is
 
    function Runtime_Dir_Of (Comp : Compiler_Access) return Name_Id is
    begin
-      if Comp = null then
-         return No_Name;
-
-      else
-         return Comp.Runtime_Dir;
-      end if;
+      return (if Comp = null then No_Name else Comp.Runtime_Dir);
    end Runtime_Dir_Of;
 
    ----------

--- a/gpr/src/gpr-names.adb
+++ b/gpr/src/gpr-names.adb
@@ -650,11 +650,8 @@ package body GPR.Names is
       Get_Name_String (U);
       Write_Str (Name_Buffer (1 .. Name_Len - 2));
 
-      if Name_Buffer (Name_Len) = 's' then
-         Write_Str (" (spec)");
-      else
-         Write_Str (" (body)");
-      end if;
+      Write_Str
+        ((if Name_Buffer (Name_Len) = 's' then " (spec)" else " (body)"));
    end Write_Unit_Name;
 
 end GPR.Names;

--- a/gpr/src/gpr-osint.adb
+++ b/gpr/src/gpr-osint.adb
@@ -238,11 +238,9 @@ package body GPR.Osint is
 
    function File_Stamp (Name : File_Name_Type) return Time_Stamp_Type is
    begin
-      if Name = No_File then
-         return Empty_Time_Stamp;
-      end if;
-
-      return File_Stamp (Get_Name_String (Name));
+      return
+        (if Name = No_File then Empty_Time_Stamp
+         else File_Stamp (Get_Name_String (Name)));
    end File_Stamp;
 
    function File_Stamp (Name : Path_Name_Type) return Time_Stamp_Type is

--- a/gpr/src/gpr-output.adb
+++ b/gpr/src/gpr-output.adb
@@ -113,17 +113,7 @@ package body GPR.Output is
             --  If line is too long or if it's a blank line, just write the
             --  buffer.
 
-            if Len > Buffer_Max
-              or else Buffer (1 .. Len) = (1 => ASCII.LF)
-            then
-               Write_Buffer (Buffer (1 .. Len));
-
-            --  Otherwise, construct a new buffer with preceding spaces, and
-            --  write that.
-
-            else
-               Write_Buffer (Buffer (1 .. Len));
-            end if;
+            Write_Buffer (Buffer (1 .. Len));
 
          exception
             when Write_Error =>

--- a/gpr/src/gpr-part.adb
+++ b/gpr/src/gpr-part.adb
@@ -1660,12 +1660,10 @@ package body GPR.Part is
             then
                Error_Msg_Name_1 := Expected_Name;
 
-               if Is_Config_File then
-                  Extension := new String'(Config_Project_File_Extension);
-
-               else
-                  Extension := new String'(Project_File_Extension);
-               end if;
+               Extension :=
+                 (if Is_Config_File then
+                    new String'(Config_Project_File_Extension)
+                  else new String'(Project_File_Extension));
 
                Error_Msg
                  (Env.Flags,
@@ -2264,15 +2262,9 @@ package body GPR.Part is
          end if;
 
          if Index >= Name_Len then
-            if Is_Alphanumeric (Name_Buffer (Name_Len)) then
-
-               --  All checks have succeeded. Return name in Name_Buffer
-
-               return Name_Find;
-
-            else
-               return No_Name;
-            end if;
+            return
+              (if Is_Alphanumeric (Name_Buffer (Name_Len)) then Name_Find
+               else No_Name);
 
          elsif Name_Buffer (Index) = '-' then
             Index := Index + 1;

--- a/gpr/src/gpr-pp.adb
+++ b/gpr/src/gpr-pp.adb
@@ -193,11 +193,9 @@ package body GPR.PP is
          end if;
 
          for J in 1 .. Name_Len loop
-            if Capital then
-               Write_Char (To_Upper (Name_Buffer (J)));
-            else
-               Write_Char (Name_Buffer (J));
-            end if;
+            Write_Char
+              ((if Capital then To_Upper (Name_Buffer (J))
+                else Name_Buffer (J)));
 
             if Capitalize then
                Capital :=
@@ -994,23 +992,12 @@ package body GPR.PP is
    --  Start of processing for Pretty_Print
 
    begin
-      if W_Char = null then
-         Write_Char := Write_Char_Default'Access;
-      else
-         Write_Char := W_Char;
-      end if;
+      Write_Char :=
+        (if W_Char = null then Write_Char_Default'Access else W_Char);
 
-      if W_Eol = null then
-         Write_Eol := Write_Eol_Default'Access;
-      else
-         Write_Eol := W_Eol;
-      end if;
+      Write_Eol := (if W_Eol = null then Write_Eol_Default'Access else W_Eol);
 
-      if W_Str = null then
-         Write_Str := Write_Str_Default'Access;
-      else
-         Write_Str := W_Str;
-      end if;
+      Write_Str := (if W_Str = null then Write_Str_Default'Access else W_Str);
 
       Print (Project, Initial_Indent);
    end Pretty_Print;

--- a/gpr/src/gpr-proc.adb
+++ b/gpr/src/gpr-proc.adb
@@ -842,15 +842,12 @@ package body GPR.Proc is
 
                         --  First, if there is a package, look into the package
 
-                        if Current_Term_Kind = N_Variable_Reference then
                            The_Variable_Id :=
-                             Shared.Packages.Table
-                               (The_Package).Decl.Variables;
-                        else
-                           The_Variable_Id :=
-                             Shared.Packages.Table
-                               (The_Package).Decl.Attributes;
-                        end if;
+                             (if Current_Term_Kind = N_Variable_Reference then
+                                Shared.Packages.Table (The_Package).Decl
+                                  .Variables
+                              else Shared.Packages.Table (The_Package).Decl
+                                  .Attributes);
 
                         while The_Variable_Id /= No_Variable
                           and then Shared.Variable_Elements.Table
@@ -867,11 +864,10 @@ package body GPR.Proc is
 
                         --  If we have not found it, look into the project
 
-                        if Current_Term_Kind = N_Variable_Reference then
-                           The_Variable_Id := The_Project.Decl.Variables;
-                        else
-                           The_Variable_Id := The_Project.Decl.Attributes;
-                        end if;
+                           The_Variable_Id :=
+                             (if Current_Term_Kind = N_Variable_Reference then
+                                The_Project.Decl.Variables
+                              else The_Project.Decl.Attributes);
 
                         while The_Variable_Id /= No_Variable
                           and then Shared.Variable_Elements.Table
@@ -885,13 +881,12 @@ package body GPR.Proc is
                      end if;
 
                      if From_Project_Node_Tree.Incomplete_With then
-                        if The_Variable_Id = No_Variable then
-                           The_Variable := Nil_Variable_Value;
-                        else
                            The_Variable :=
-                             Shared.Variable_Elements.Table
-                               (The_Variable_Id).Value;
-                        end if;
+                             (if The_Variable_Id = No_Variable then
+                                Nil_Variable_Value
+                              else Shared.Variable_Elements.Table
+                                  (The_Variable_Id)
+                                  .Value);
 
                      else
                         pragma Assert (The_Variable_Id /= No_Variable,
@@ -951,12 +946,10 @@ package body GPR.Proc is
                         end Same_Index;
 
                      begin
-                        if The_Package /= No_Package then
                            The_Array :=
-                             Shared.Packages.Table (The_Package).Decl.Arrays;
-                        else
-                           The_Array := The_Project.Decl.Arrays;
-                        end if;
+                             (if The_Package /= No_Package then
+                                Shared.Packages.Table (The_Package).Decl.Arrays
+                              else The_Project.Decl.Arrays);
 
                         while The_Array /= No_Array
                           and then
@@ -992,33 +985,27 @@ package body GPR.Proc is
                              Shared.Array_Elements.Table (The_Element).Value;
 
                         else
-                           if Expression_Kind_Of
-                               (The_Current_Term, From_Project_Node_Tree) =
-                                                                       List
-                           then
                               The_Variable :=
-                                (Project              => Project,
-                                 Kind                 => List,
-                                 Location             => No_Location,
-                                 Default              => True,
-                                 String_Type          => Empty_Project_Node,
-                                 Values               => Nil_String,
-                                 Concat               =>
-                                   Is_Config_Concatenable
+                                (if
+                                   Expression_Kind_Of
                                      (The_Current_Term,
-                                      From_Project_Node_Tree),
-                                 From_Implicit_Target => False);
-                           else
-                              The_Variable :=
-                                (Project              => Project,
-                                 Kind                 => Single,
-                                 Location             => No_Location,
-                                 Default              => True,
-                                 String_Type          => Empty_Project_Node,
-                                 Value                => Empty_String,
-                                 Index                => 0,
-                                 From_Implicit_Target => False);
-                           end if;
+                                      From_Project_Node_Tree) =
+                                   List
+                                 then
+                                   (Project     => Project, Kind => List,
+                                    Location => No_Location, Default => True,
+                                    String_Type => Empty_Project_Node,
+                                    Values      => Nil_String,
+                                    Concat      =>
+                                      Is_Config_Concatenable
+                                        (The_Current_Term,
+                                         From_Project_Node_Tree),
+                                    From_Implicit_Target => False)
+                                 else (Project => Project, Kind => Single,
+                                    Location => No_Location, Default => True,
+                                    String_Type          => Empty_Project_Node,
+                                    Value => Empty_String, Index => 0,
+                                    From_Implicit_Target => False));
                         end if;
                      end;
                   end if;
@@ -1098,13 +1085,14 @@ package body GPR.Proc is
                                     end if;
 
                                  when Canonical_Target_Value =>
-                                    if Opt.Target_Value_Canonical = null then
-                                       The_Variable.Value := Empty_String;
-
-                                    else
-                                       The_Variable.Value := Get_Name_Id
-                                         (Opt.Target_Value_Canonical.all);
-                                    end if;
+                                          The_Variable.Value :=
+                                            (if
+                                               Opt.Target_Value_Canonical =
+                                               null
+                                             then Empty_String
+                                             else Get_Name_Id
+                                                 (Opt
+                                                    .Target_Value_Canonical.all));
 
                                  when Runtime_Value =>
                                     null;
@@ -1584,11 +1572,7 @@ package body GPR.Proc is
          begin
             while Proj /= No_Project loop
                if Proj.Name = With_Name then
-                  if No_Extending then
-                     Temp_Result := Proj;
-                  else
-                     Temp_Result := Result;
-                  end if;
+                  Temp_Result := (if No_Extending then Proj else Result);
 
                   exit;
                end if;
@@ -1630,7 +1614,7 @@ package body GPR.Proc is
                      return Result;
 
                   elsif Util.Starts_With
-                          (Get_Name_String (Result.Name), Grand & '.')
+                      (Get_Name_String (Result.Name), Grand & '.')
                   then
                      Result := Recursive_Parent_Search (Result);
 
@@ -1642,11 +1626,10 @@ package body GPR.Proc is
                   List := List.Next;
                end loop;
 
-               if Proj.Extends /= No_Project then
-                  return Recursive_Parent_Search (Proj.Extends);
-               end if;
-
-               return No_Project;
+               return
+                 (if Proj.Extends /= No_Project then
+                    Recursive_Parent_Search (Proj.Extends)
+                  else No_Project);
             end Recursive_Parent_Search;
 
          begin
@@ -1819,12 +1802,9 @@ package body GPR.Proc is
                Str_Type : constant Project_Node_Id :=
                  String_Type_Of (Declaration, Node_Tree);
             begin
-               if No (Str_Type) then
-                  Current_String := Empty_Project_Node;
-
-               else
-                  Current_String := First_Literal_String (Str_Type, Node_Tree);
-               end if;
+               Current_String :=
+                 (if No (Str_Type) then Empty_Project_Node
+                  else First_Literal_String (Str_Type, Node_Tree));
 
                while Present (Current_String)
                  and then
@@ -2043,11 +2023,9 @@ package body GPR.Proc is
          --  First find if the associative array attribute already has elements
          --  declared.
 
-         if Pkg /= No_Package then
-            New_Array := Shared.Packages.Table (Pkg).Decl.Arrays;
-         else
-            New_Array := Project.Decl.Arrays;
-         end if;
+         New_Array :=
+           (if Pkg /= No_Package then Shared.Packages.Table (Pkg).Decl.Arrays
+            else Project.Decl.Arrays);
 
          while New_Array /= No_Array
            and then Shared.Arrays.Table (New_Array).Name /= Current_Item_Name
@@ -2249,11 +2227,9 @@ package body GPR.Proc is
 
          --  Look for the array in the appropriate list
 
-         if Pkg /= No_Package then
-            The_Array := Shared.Packages.Table (Pkg).Decl.Arrays;
-         else
-            The_Array := Project.Decl.Arrays;
-         end if;
+         The_Array :=
+           (if Pkg /= No_Package then Shared.Packages.Table (Pkg).Decl.Arrays
+            else Project.Decl.Arrays);
 
          while The_Array /= No_Array
            and then Shared.Arrays.Table (The_Array).Name /= Name
@@ -2372,18 +2348,16 @@ package body GPR.Proc is
          --  First, find the list where to find the variable or attribute
 
          if Is_Attribute then
-            if Pkg /= No_Package then
-               Var := Shared.Packages.Table (Pkg).Decl.Attributes;
-            else
-               Var := Project.Decl.Attributes;
-            end if;
+            Var :=
+              (if Pkg /= No_Package then
+                 Shared.Packages.Table (Pkg).Decl.Attributes
+               else Project.Decl.Attributes);
 
          else
-            if Pkg /= No_Package then
-               Var := Shared.Packages.Table (Pkg).Decl.Variables;
-            else
-               Var := Project.Decl.Variables;
-            end if;
+            Var :=
+              (if Pkg /= No_Package then
+                 Shared.Packages.Table (Pkg).Decl.Variables
+               else Project.Decl.Variables);
          end if;
 
          --  Loop through the list, to find if it has already been declared
@@ -3052,11 +3026,9 @@ package body GPR.Proc is
                --  In aggregate library, aggregated projects are parsed using
                --  the aggregate library tree.
 
-               if Project.Qualifier = Aggregate_Library then
-                  Tree := In_Tree;
-               else
-                  Tree := List.Tree;
-               end if;
+               Tree :=
+                 (if Project.Qualifier = Aggregate_Library then In_Tree
+                  else List.Tree);
 
                --  We can only do the phase 1 of the processing, since we do
                --  not have access to the configuration file yet (this is

--- a/gpr/src/gpr-script.adb
+++ b/gpr/src/gpr-script.adb
@@ -64,11 +64,7 @@ package body GPR.Script is
          end if;
       end loop;
 
-      if Need_Quoting then
-         return "'" & Arg (1 .. Last) & "'";
-      else
-         return S;
-      end if;
+      return (if Need_Quoting then "'" & Arg (1 .. Last) & "'" else S);
    end Potentially_Quoted;
 
    -----------------------

--- a/gpr/src/gpr-sinput.adb
+++ b/gpr/src/gpr-sinput.adb
@@ -446,12 +446,12 @@ package body GPR.Sinput is
       Source_File.Increment_Last;
       X := Source_File.Last;
 
-      if X = Source_File.First then
-         Lo := First_Source_Ptr;
-      else
-         Lo := ((Source_File.Table (X - 1).Source_Last + Source_Align) /
-                  Source_Align) * Source_Align;
-      end if;
+      Lo :=
+        (if X = Source_File.First then First_Source_Ptr
+         else
+           ((Source_File.Table (X - 1).Source_Last + Source_Align) /
+            Source_Align) *
+           Source_Align);
 
       Name_Buffer (Name_Len + 1) := ASCII.NUL;
 

--- a/gpr/src/gpr-strt.adb
+++ b/gpr/src/gpr-strt.adb
@@ -453,11 +453,7 @@ package body GPR.Strt is
       end if;
 
       if Expr_Kind = Undefined then
-         if Ext_List then
-            Expr_Kind := List;
-         else
-            Expr_Kind := Single;
-         end if;
+         Expr_Kind := (if Ext_List then List else Single);
       end if;
 
       Expect (Tok_Left_Paren, "`(`");
@@ -888,16 +884,13 @@ package body GPR.Strt is
 
                   --  Now, look if it can be a project name
 
-                  if Names.Table (1).Name =
+                  The_Project :=
+                    (if
+                       Names.Table (1).Name =
                        Name_Of (Current_Project, In_Tree)
-                  then
-                     The_Project := Current_Project;
-
-                  else
-                     The_Project :=
-                       Imported_Or_Extended_Project_Of
-                         (Current_Project, In_Tree, Names.Table (1).Name);
-                  end if;
+                     then Current_Project
+                     else Imported_Or_Extended_Project_Of
+                         (Current_Project, In_Tree, Names.Table (1).Name));
 
                   if No (The_Project) then
 
@@ -989,16 +982,11 @@ package body GPR.Strt is
 
                      --  Check if the long project is imported or extended
 
-                     if Long_Project = Name_Of (Current_Project, In_Tree) then
-                        The_Project := Current_Project;
-
-                     else
-                        The_Project :=
-                          Imported_Or_Extended_Project_Of
-                            (Current_Project,
-                             In_Tree,
-                             Long_Project);
-                     end if;
+                     The_Project :=
+                       (if Long_Project = Name_Of (Current_Project, In_Tree)
+                        then Current_Project
+                        else Imported_Or_Extended_Project_Of
+                            (Current_Project, In_Tree, Long_Project));
 
                      --  If the long project exists, then this is the prefix
                      --  of the attribute.
@@ -1011,16 +999,12 @@ package body GPR.Strt is
                         --  Otherwise, check if the short project is imported
                         --  or extended.
 
-                        if Short_Project =
-                             Name_Of (Current_Project, In_Tree)
-                        then
-                           The_Project := Current_Project;
-
-                        else
-                           The_Project := Imported_Or_Extended_Project_Of
-                                            (Current_Project, In_Tree,
-                                             Short_Project);
-                        end if;
+                        The_Project :=
+                          (if
+                             Short_Project = Name_Of (Current_Project, In_Tree)
+                           then Current_Project
+                           else Imported_Or_Extended_Project_Of
+                               (Current_Project, In_Tree, Short_Project));
 
                         --  If short project does not exist, report an error
 
@@ -1250,11 +1234,9 @@ package body GPR.Strt is
          Set_Project_Node_Of (Variable, In_Tree, To => Specified_Project);
          Set_Package_Node_Of (Variable, In_Tree, To => Specified_Package);
 
-         if Present (Specified_Project) then
-            The_Project := Specified_Project;
-         else
-            The_Project := Current_Project;
-         end if;
+         The_Project :=
+           (if Present (Specified_Project) then Specified_Project
+            else Current_Project);
 
          Current_Variable := Empty_Project_Node;
 
@@ -1319,13 +1301,11 @@ package body GPR.Strt is
                      --  the variable is declared in one of the projects the
                      --  current project extends.
 
-                     if No (Parent_Project_Of (Proj, In_Tree)) then
-                        Proj :=
+                     Proj :=
+                       (if No (Parent_Project_Of (Proj, In_Tree)) then
                           Extended_Project_Of
-                            (Project_Declaration_Of (Proj, In_Tree), In_Tree);
-                     else
-                        Proj := Parent_Project_Of (Proj, In_Tree);
-                     end if;
+                            (Project_Declaration_Of (Proj, In_Tree), In_Tree)
+                        else Parent_Project_Of (Proj, In_Tree));
 
                      Set_Project_Node_Of (Variable, In_Tree, To => Proj);
 

--- a/gpr/src/gpr-tempdir.adb
+++ b/gpr/src/gpr-tempdir.adb
@@ -71,11 +71,7 @@ package body GPR.Tempdir is
 
       function Directory return String is
       begin
-         if Temp_Dir'Length /= 0 then
-            return Temp_Dir.all;
-         else
-            return Current_Dir;
-         end if;
+         return (if Temp_Dir'Length /= 0 then Temp_Dir.all else Current_Dir);
       end Directory;
 
    --  Start of processing for Create_Temp_File
@@ -200,11 +196,7 @@ package body GPR.Tempdir is
 
    function Temporary_Directory_Path return String is
    begin
-      if Temp_Dir /= null then
-         return Temp_Dir.all;
-      else
-         return "";
-      end if;
+      return (if Temp_Dir /= null then Temp_Dir.all else "");
    end Temporary_Directory_Path;
 
 --  Start of elaboration for package Tempdir

--- a/gpr/src/gpr-tree.adb
+++ b/gpr/src/gpr-tree.adb
@@ -470,11 +470,9 @@ package body GPR.Tree is
       pragma Assert (Present (Node));
       Zone := In_Tree.Project_Nodes.Table (Node).Comments;
 
-      if No (Zone) then
-         return No_Name;
-      else
-         return In_Tree.Project_Nodes.Table (Zone).Value;
-      end if;
+      return
+        (if No (Zone) then No_Name
+         else In_Tree.Project_Nodes.Table (Zone).Value);
    end End_Of_Line_Comment;
 
    ------------------------
@@ -684,12 +682,9 @@ package body GPR.Tree is
       pragma Assert (Present (Node));
       Zone := In_Tree.Project_Nodes.Table (Node).Comments;
 
-      if No (Zone) then
-         return Empty_Project_Node;
-
-      else
-         return In_Tree.Project_Nodes.Table (Zone).Field2;
-      end if;
+      return
+        (if No (Zone) then Empty_Project_Node
+         else In_Tree.Project_Nodes.Table (Zone).Field2);
    end First_Comment_After;
 
    -----------------------------
@@ -707,12 +702,9 @@ package body GPR.Tree is
       pragma Assert (Present (Node));
       Zone := In_Tree.Project_Nodes.Table (Node).Comments;
 
-      if No (Zone) then
-         return Empty_Project_Node;
-
-      else
-         return In_Tree.Project_Nodes.Table (Zone).Comments;
-      end if;
+      return
+        (if No (Zone) then Empty_Project_Node
+         else In_Tree.Project_Nodes.Table (Zone).Comments);
    end First_Comment_After_End;
 
    --------------------------
@@ -729,12 +721,9 @@ package body GPR.Tree is
       pragma Assert (Present (Node));
       Zone := In_Tree.Project_Nodes.Table (Node).Comments;
 
-      if No (Zone) then
-         return Empty_Project_Node;
-
-      else
-         return In_Tree.Project_Nodes.Table (Zone).Field1;
-      end if;
+      return
+        (if No (Zone) then Empty_Project_Node
+         else In_Tree.Project_Nodes.Table (Zone).Field1);
    end First_Comment_Before;
 
    ------------------------------
@@ -751,12 +740,9 @@ package body GPR.Tree is
       pragma Assert (Present (Node));
       Zone := In_Tree.Project_Nodes.Table (Node).Comments;
 
-      if No (Zone) then
-         return Empty_Project_Node;
-
-      else
-         return In_Tree.Project_Nodes.Table (Zone).Field3;
-      end if;
+      return
+        (if No (Zone) then Empty_Project_Node
+         else In_Tree.Project_Nodes.Table (Zone).Field3);
    end First_Comment_Before_End;
 
    -------------------------------
@@ -775,11 +761,10 @@ package body GPR.Tree is
              | N_Case_Item
              | N_Package_Declaration);
 
-      if In_Tree.Project_Nodes.Table (Node).Kind = N_Project_Declaration then
-         return In_Tree.Project_Nodes.Table (Node).Field1;
-      else
-         return In_Tree.Project_Nodes.Table (Node).Field2;
-      end if;
+      return
+        (if In_Tree.Project_Nodes.Table (Node).Kind = N_Project_Declaration
+         then In_Tree.Project_Nodes.Table (Node).Field1
+         else In_Tree.Project_Nodes.Table (Node).Field2);
    end First_Declarative_Item_Of;
 
    ------------------------------
@@ -2886,11 +2871,10 @@ package body GPR.Tree is
          and then In_Tree.Project_Nodes.Table (Node).Kind in
              N_Variable_Reference | N_Typed_Variable_Declaration);
 
-      if In_Tree.Project_Nodes.Table (Node).Kind = N_Variable_Reference then
-         return In_Tree.Project_Nodes.Table (Node).Field3;
-      else
-         return In_Tree.Project_Nodes.Table (Node).Field2;
-      end if;
+      return
+        (if In_Tree.Project_Nodes.Table (Node).Kind = N_Variable_Reference then
+           In_Tree.Project_Nodes.Table (Node).Field3
+         else In_Tree.Project_Nodes.Table (Node).Field2);
    end String_Type_Of;
 
    ---------------------
@@ -3023,11 +3007,10 @@ package body GPR.Tree is
          New_Decl := Expr;
       end if;
 
-      if Kind_Of (Parent, Tree) = N_Project then
-         Real_Parent := Project_Declaration_Of (Parent, Tree);
-      else
-         Real_Parent := Parent;
-      end if;
+      Real_Parent :=
+        (if Kind_Of (Parent, Tree) = N_Project then
+           Project_Declaration_Of (Parent, Tree)
+         else Parent);
 
       Decl := First_Declarative_Item_Of (Real_Parent, Tree);
 

--- a/gpr/src/gpr-util-aux.adb
+++ b/gpr/src/gpr-util-aux.adb
@@ -370,14 +370,10 @@ package body GPR.Util.Aux is
          Status :=
            Write (Resp_File, Object (1)'Address, Object'Length);
 
-         if Format = GNU or else Format = GCC_GNU then
-            Status :=
-              Write (Resp_File, GNU_Closing'Address, GNU_Closing'Length);
-
-         else
-            Status :=
-              Write (Resp_File, ASCII.LF'Address, 1);
-         end if;
+         Status :=
+           (if Format = GNU or else Format = GCC_GNU then
+              Write (Resp_File, GNU_Closing'Address, GNU_Closing'Length)
+            else Write (Resp_File, ASCII.LF'Address, 1));
       end loop;
 
       if Format = GNU or else Format = GCC_GNU then

--- a/gpr/src/gpr-util-knowledge.adb
+++ b/gpr/src/gpr-util-knowledge.adb
@@ -71,11 +71,9 @@ package body Knowledge is
 
       function Dir return String is
       begin
-         if Directory'Length = 0 then
-            return Default_Knowledge_Base_Directory;
-         else
-            return Directory;
-         end if;
+         return
+           (if Directory'Length = 0 then Default_Knowledge_Base_Directory
+            else Directory);
       end Dir;
 
    begin

--- a/gpr/src/gpr-util.adb
+++ b/gpr/src/gpr-util.adb
@@ -138,11 +138,7 @@ package body GPR.Util is
       function strlen (A : Address) return size_t;
       pragma Import (Intrinsic, strlen, "strlen");
    begin
-      if S = Null_Address then
-         return 0;
-      else
-         return Integer (strlen (S));
-      end if;
+      return (if S = Null_Address then 0 else Integer (strlen (S)));
    end C_String_Length;
 
    ------------------------
@@ -402,11 +398,10 @@ package body GPR.Util is
 
    function "<" (Left, Right : Main_Project_Tree) return Boolean is
    begin
-      if Left.Project.Name /= Right.Project.Name then
-         return Left.Project.Name < Right.Project.Name;
-      else
-         return Left.Main.File < Right.Main.File;
-      end if;
+      return
+        (if Left.Project.Name /= Right.Project.Name then
+           Left.Project.Name < Right.Project.Name
+         else Left.Main.File < Right.Main.File);
    end "<";
 
    -----------
@@ -498,17 +493,11 @@ package body GPR.Util is
    begin
       loop
          if At_A > A'Last then
-            if At_B > B'Last or else B (At_B) = '/' then
-               return A'Length;
-            else
-               return Slash - A'First;
-            end if;
+            return
+              (if At_B > B'Last or else B (At_B) = '/' then A'Length
+               else Slash - A'First);
          elsif At_B > B'Last then
-            if A (At_A) = '/' then  --  A cannot be shorter than B here
-               return B'Length;
-            else
-               return Slash - A'First;
-            end if;
+            return (if A (At_A) = '/' then B'Length else Slash - A'First);
          elsif A (At_A) /= B (At_B) then
             return Slash - A'First;
          elsif A (At_A) = '/' then
@@ -818,15 +807,15 @@ package body GPR.Util is
             To_Lower (Exec (Path_Last - 2 .. Path_Last));
          end if;
 
-         if Path_Last < Exec'First + 2
-           or else Exec (Path_Last - 2 .. Path_Last) /= "bin"
-           or else (Path_Last - 3 >= Exec'First
-                    and then not Is_Directory_Separator (Exec (Path_Last - 3)))
-         then
-            return "";
-         end if;
-
-         return (Exec (Exec'First .. Path_Last - 4)) & Directory_Separator;
+         return
+           (if
+              Path_Last < Exec'First + 2
+              or else Exec (Path_Last - 2 .. Path_Last) /= "bin"
+              or else
+              (Path_Last - 3 >= Exec'First
+               and then not Is_Directory_Separator (Exec (Path_Last - 3)))
+            then ""
+            else (Exec (Exec'First .. Path_Last - 4)) & Directory_Separator);
       end Get_Install_Dir;
 
    --  Beginning of Executable_Prefix_Path
@@ -997,11 +986,9 @@ package body GPR.Util is
    --  Start of processing for For_Interface_Sources
 
    begin
-      if Project.Qualifier = Aggregate_Library then
-         Iter := For_Each_Source (Tree);
-      else
-         Iter := For_Each_Source (Tree, Project);
-      end if;
+      Iter :=
+        (if Project.Qualifier = Aggregate_Library then For_Each_Source (Tree)
+         else For_Each_Source (Tree, Project));
 
       --  First look at each spec, check if the body is needed
 
@@ -1077,11 +1064,10 @@ package body GPR.Util is
       --  Now handle the bodies and separates if needed
 
       if Deps.Length /= 0 then
-         if Project.Qualifier = Aggregate_Library then
-            Iter := For_Each_Source (Tree);
-         else
-            Iter := For_Each_Source (Tree, Project);
-         end if;
+         Iter :=
+           (if Project.Qualifier = Aggregate_Library then
+              For_Each_Source (Tree)
+            else For_Each_Source (Tree, Project));
 
          loop
             Sid := Element (Iter);
@@ -1401,11 +1387,7 @@ package body GPR.Util is
 
             Proj : Project_Id;
          begin
-            if All_Projects then
-               Proj := No_Project;
-            else
-               Proj := Project;
-            end if;
+            Proj := (if All_Projects then No_Project else Project);
 
             Iter := For_Each_Source
               (In_Tree           => Tree,
@@ -1934,11 +1916,9 @@ package body GPR.Util is
    is
       Ind : constant Natural := Source_Info_Project_HTable.Get (For_Project);
    begin
-      if Ind = 0 then
-         Iter := (No_Source_Info, 0);
-      else
-         Iter := Source_Info_Table.Table (Ind);
-      end if;
+      Iter :=
+        (if Ind = 0 then (No_Source_Info, 0)
+         else Source_Info_Table.Table (Ind));
    end Initialize;
 
    ------------------------------
@@ -2293,11 +2273,9 @@ package body GPR.Util is
                   Filename'Last - Pragma_Config_File_Suffix'Length + 1;
       E_Last  : constant Integer := Filename'Last;
    begin
-      if Filename'Length > Pragma_Config_File_Suffix'Length then
-         return (Filename (E_First .. E_Last) = Pragma_Config_File_Suffix);
-      else
-         return False;
-      end if;
+      return
+        Filename'Length > Pragma_Config_File_Suffix'Length
+        and then (Filename (E_First .. E_Last) = Pragma_Config_File_Suffix);
    end Is_Pragmas_Config_File;
 
    ----------------
@@ -2880,14 +2858,12 @@ package body GPR.Util is
      (Variable : Variable_Value;
       Default  : String) return String is
    begin
-      if Variable.Kind /= Single
-        or else Variable.Default
-        or else Variable.Value = No_Name
-      then
-         return Default;
-      else
-         return Get_Name_String (Variable.Value);
-      end if;
+      return
+        (if
+           Variable.Kind /= Single or else Variable.Default
+           or else Variable.Value = No_Name
+         then Default
+         else Get_Name_String (Variable.Value));
    end Value_Of;
 
    function Value_Of
@@ -3501,13 +3477,10 @@ package body GPR.Util is
 
    function Ensure_Directory (Path : String) return String is
    begin
-      if Path'Length = 0
-        or else Is_Directory_Separator (Path (Path'Last))
-      then
-         return Path;
-      else
-         return Path & Directory_Separator;
-      end if;
+      return
+        (if Path'Length = 0 or else Is_Directory_Separator (Path (Path'Last))
+         then Path
+         else Path & Directory_Separator);
    end Ensure_Directory;
 
    ----------------------
@@ -3533,13 +3506,12 @@ package body GPR.Util is
 
    function Ensure_Suffix (Item : String; Suffix : String) return String is
    begin
-      if Item'Length >= Suffix'Length
-        and then Item (Item'Last - Suffix'Length + 1 .. Item'Last) = Suffix
-      then
-         return Item;
-      else
-         return Item & Suffix;
-      end if;
+      return
+        (if
+           Item'Length >= Suffix'Length
+           and then Item (Item'Last - Suffix'Length + 1 .. Item'Last) = Suffix
+         then Item
+         else Item & Suffix);
    end Ensure_Suffix;
 
 --     ---------------
@@ -3874,11 +3846,9 @@ package body GPR.Util is
                         & " for Lang", Language_Name);
                   end if;
 
-                  if Config.Binder_Prefix = No_Name then
-                     Binder_Prefix := Empty_String;
-                  else
-                     Binder_Prefix := Config.Binder_Prefix;
-                  end if;
+                  Binder_Prefix :=
+                    (if Config.Binder_Prefix = No_Name then Empty_String
+                     else Config.Binder_Prefix);
 
                   B_Index := Data.Binding;
                   while B_Index /= null loop
@@ -3926,11 +3896,10 @@ package body GPR.Util is
 
    function Get_Target return String is
    begin
-      if Target_Name = null or else Target_Name.all = "" then
-         return Sdefault.Hostname;
-      else
-         return Target_Name.all;
-      end if;
+      return
+        (if Target_Name = null or else Target_Name.all = "" then
+           Sdefault.Hostname
+         else Target_Name.all);
    end Get_Target;
 
    --------------------
@@ -4130,11 +4099,8 @@ package body GPR.Util is
          end loop;
       end if;
 
-      if Ok_Maj then
-         return Maj_Version (Maj_Version'First .. Last_Maj);
-      else
-         return "";
-      end if;
+      return
+        (if Ok_Maj then Maj_Version (Maj_Version'First .. Last_Maj) else "");
    end Major_Id_Name;
 
    ------------------
@@ -5012,13 +4978,12 @@ package body GPR.Util is
                   Put (Get_Name_String (GNAT_Version));
                   Put ("; expected version = ");
 
-                  if Tree.Shared.Ada_Runtime_Library_Version /= No_Name then
-                     Put_Line
-                       (Get_Name_String
-                         (Tree.Shared.Ada_Runtime_Library_Version));
-                  else
-                     Put_Line ("unknown");
-                  end if;
+                  Put_Line
+                    ((if Tree.Shared.Ada_Runtime_Library_Version /= No_Name
+                      then
+                        Get_Name_String
+                          (Tree.Shared.Ada_Runtime_Library_Version)
+                      else "unknown"));
                end if;
 
                return True;
@@ -6089,12 +6054,9 @@ package body GPR.Util is
 
    function Command_Line_Argument (Rank : Positive) return String is
    begin
-      if Rank > Command_Line_Arguments.Last then
-         return "";
-
-      else
-         return Get_Name_String (Command_Line_Arguments.Table (Rank));
-      end if;
+      return
+        (if Rank > Command_Line_Arguments.Last then ""
+         else Get_Name_String (Command_Line_Arguments.Table (Rank)));
    end Command_Line_Argument;
 
 begin

--- a/gpr/src/gpr.adb
+++ b/gpr/src/gpr.adb
@@ -150,12 +150,7 @@ package body GPR is
 
    begin
       if Directory'Length /= 0 then
-         if not Exists (Variable) then
-            Update ("");
-
-         else
-            Update (Value (Variable));
-         end if;
+         Update ((if Exists (Variable) then Value (Variable) else ""));
       end if;
    end Add_To_Path;
 
@@ -283,11 +278,9 @@ package body GPR is
 
    begin
       if not Opt.Keep_Temporary_Files then
-         if Shared = null then
-            Instance := Temp_Files;
-         else
-            Instance := Shared.Private_Part.Temp_Files;
-         end if;
+         Instance :=
+           (if Shared = null then Temp_Files
+            else Shared.Private_Part.Temp_Files);
 
          for Index in
            1 .. Temp_Files_Table.Last (Instance)
@@ -318,11 +311,9 @@ package body GPR is
             end if;
          end loop;
 
-         if Shared = null then
-            Temp_Files_Table.Init (Temp_Files);
-         else
-            Temp_Files_Table.Init (Shared.Private_Part.Temp_Files);
-         end if;
+         Temp_Files_Table.Init
+           ((if Shared = null then Temp_Files
+             else Shared.Private_Part.Temp_Files));
       end if;
 
       if Shared /= null then
@@ -1154,11 +1145,9 @@ package body GPR is
 
    function Hash (Project : Project_Id) return Header_Num is
    begin
-      if Project = No_Project then
-         return Header_Num'First;
-      else
-         return Hash (Project.Name);
-      end if;
+      return
+        (if Project = No_Project then Header_Num'First
+         else Hash (Project.Name));
    end Hash;
 
    ---------------
@@ -1296,13 +1285,11 @@ package body GPR is
       Object_File_Suffix : Name_Id := No_Name) return File_Name_Type
    is
    begin
-      if Object_File_Suffix = No_Name then
-         return Extend_Name
-           (Source_File_Name, Object_Suffix);
-      else
-         return Extend_Name
-           (Source_File_Name, Get_Name_String (Object_File_Suffix));
-      end if;
+      return
+        (if Object_File_Suffix = No_Name then
+           Extend_Name (Source_File_Name, Object_Suffix)
+         else Extend_Name
+             (Source_File_Name, Get_Name_String (Object_File_Suffix)));
    end Object_Name;
 
    function Object_Name
@@ -1836,16 +1823,15 @@ package body GPR is
          --  files; otherwise add the object directory.
 
          if Project.Library then
-            if Project.Object_Directory = No_Path_Information
-              or else
-                (Including_Libraries
-                  and then
-                    Contains_ALI_Files (Project.Library_ALI_Dir.Display_Name))
-            then
-               return Project.Library_ALI_Dir.Display_Name;
-            else
-               return Project.Object_Directory.Display_Name;
-            end if;
+            return
+              (if
+                 Project.Object_Directory = No_Path_Information
+                 or else
+                 (Including_Libraries
+                  and then Contains_ALI_Files
+                    (Project.Library_ALI_Dir.Display_Name))
+               then Project.Library_ALI_Dir.Display_Name
+               else Project.Object_Directory.Display_Name);
 
             --  For a non-library project, add object directory if it is not a
             --  virtual project, and if there are Ada sources in the project or
@@ -2200,11 +2186,9 @@ package body GPR is
          Set_Standard_Error;
          Write_Str (Str);
 
-         if Str2 = No_Name then
-            Write_Line (" <no_name>");
-         else
-            Write_Line (" """ & Get_Name_String (Str2) & '"');
-         end if;
+         Write_Line
+           ((if Str2 = No_Name then " <no_name>"
+             else " """ & Get_Name_String (Str2) & '"'));
 
          Set_Standard_Output;
       end if;

--- a/gpr/src/gpr_build_util.adb
+++ b/gpr/src/gpr_build_util.adb
@@ -439,13 +439,10 @@ package body Gpr_Build_Util is
                      --  For library projects, use the library ALI directory,
                      --  for other projects, use the object directory.
 
-                     if ALI_Project.Library then
-                        Get_Name_String
-                          (ALI_Project.Library_ALI_Dir.Display_Name);
-                     else
-                        Get_Name_String
-                          (ALI_Project.Object_Directory.Display_Name);
-                     end if;
+                     Get_Name_String
+                       ((if ALI_Project.Library then
+                           ALI_Project.Library_ALI_Dir.Display_Name
+                         else ALI_Project.Object_Directory.Display_Name));
 
                      Add_Str_To_Name_Buffer (ALI);
 
@@ -515,12 +512,7 @@ package body Gpr_Build_Util is
       --  If the creation of the mapping file was successful, we add the switch
       --  to the arguments of gnatbind.
 
-      if OK then
-         return Mapping_Path;
-
-      else
-         return No_Path;
-      end if;
+      return (if OK then Mapping_Path else No_Path);
    end Create_Binder_Mapping_File;
 
    -----------------
@@ -719,12 +711,10 @@ package body Gpr_Build_Util is
             end if;
 
          elsif Project.Library then
-            if Activity = SAL_Binding and then Extended then
-               Add_Dir (Project.Object_Directory.Display_Name);
-
-            else
-               Add_Dir (Project.Library_ALI_Dir.Display_Name);
-            end if;
+            Add_Dir
+              ((if Activity = SAL_Binding and then Extended then
+                  Project.Object_Directory.Display_Name
+                else Project.Library_ALI_Dir.Display_Name));
 
          else
             Add_Dir (Project.Object_Directory.Display_Name);
@@ -766,11 +756,10 @@ package body Gpr_Build_Util is
          declare
             Name : constant String := Get_Name_String (N);
          begin
-            if Debug.Debug_Flag_F and then Is_Absolute_Path (Name) then
-               Write_Str (File_Name (Name));
-            else
-               Write_Str (Name);
-            end if;
+            Write_Str
+              ((if Debug.Debug_Flag_F and then Is_Absolute_Path (Name) then
+                  File_Name (Name)
+                else Name));
          end;
 
          Write_Str (""" ");
@@ -1390,11 +1379,8 @@ package body Gpr_Build_Util is
       function Next_Main return String is
          Info : constant Main_Info := Next_Main;
       begin
-         if Info = No_Main_Info then
-            return "";
-         else
-            return Get_Name_String (Info.File);
-         end if;
+         return
+           (if Info = No_Main_Info then "" else Get_Name_String (Info.File));
       end Next_Main;
 
       function Next_Main return Main_Info is
@@ -1413,11 +1399,9 @@ package body Gpr_Build_Util is
 
       function Number_Of_Mains (Tree : Project_Tree_Ref) return Natural is
       begin
-         if Tree = null then
-            return Names.Last_Index;
-         else
-            return Builder_Data (Tree).Number_Of_Mains;
-         end if;
+         return
+           (if Tree = null then Names.Last_Index
+            else Builder_Data (Tree).Number_Of_Mains);
       end Number_Of_Mains;
 
       -----------
@@ -1467,11 +1451,7 @@ package body Gpr_Build_Util is
    function Path_Or_File_Name (Path : Path_Name_Type) return String is
       Path_Name : constant String := Get_Name_String (Path);
    begin
-      if Debug.Debug_Flag_F then
-         return File_Name (Path_Name);
-      else
-         return Path_Name;
-      end if;
+      return (if Debug.Debug_Flag_F then File_Name (Path_Name) else Path_Name);
    end Path_Or_File_Name;
 
    -----------------
@@ -1863,17 +1843,14 @@ package body Gpr_Build_Util is
                      exit Source_Loop when Root_Source = No_Source;
 
                      Root_Found := False;
-                     if Pat_Root then
-                        Root_Found := Root_Source.Unit /= No_Unit_Index
+                     Root_Found :=
+                       (if Pat_Root then
+                          Root_Source.Unit /= No_Unit_Index
                           and then Match
                             (Get_Name_String (Root_Source.Unit.Name),
-                             Root_Pattern);
-
-                     else
-                        Root_Found :=
-                          Root_Source.Unit /= No_Unit_Index
-                            and then Root_Source.Unit.Name = Unit_Name;
-                     end if;
+                             Root_Pattern)
+                        else Root_Source.Unit /= No_Unit_Index
+                          and then Root_Source.Unit.Name = Unit_Name);
 
                      if Root_Found then
                         case Root_Source.Kind is
@@ -2020,11 +1997,8 @@ package body Gpr_Build_Util is
 
       function Element (Rank : Positive) return File_Name_Type is
       begin
-         if Rank <= Q.Last then
-            return Q.Table (Rank).Info.Id.File;
-         else
-            return No_File;
-         end if;
+         return
+           (if Rank <= Q.Last then Q.Table (Rank).Info.Id.File else No_File);
       end Element;
 
       ----------------------------
@@ -2119,11 +2093,10 @@ package body Gpr_Build_Util is
                   then
                      --  Always provide a non null location
 
-                     if Source.Location = No_Location then
-                        Location := Source.Project.Location;
-                     else
-                        Location := Source.Location;
-                     end if;
+                     Location :=
+                       (if Source.Location = No_Location then
+                          Source.Project.Location
+                        else Source.Location);
 
                      Error_Msg_Name_1 := Source.Language.Display_Name;
                      Error_Msg_File_1 := Source.File;

--- a/src/create_ada_runtime_project.adb
+++ b/src/create_ada_runtime_project.adb
@@ -129,12 +129,8 @@ procedure Create_Ada_Runtime_Project is
 
    function Equal (K1, K2 : String_Access) return Boolean is
    begin
-      if K1 = null or else K2 = null then
-         return K1 = K2;
-
-      else
-         return K1.all = K2.all;
-      end if;
+      return
+        (if K1 = null or else K2 = null then K1 = K2 else K1.all = K2.all);
    end Equal;
 
    ----------
@@ -194,12 +190,7 @@ procedure Create_Ada_Runtime_Project is
 
    function Hash (Key : String_Access) return Header_Num is
    begin
-      if Key = null then
-         return 0;
-
-      else
-         return Hash (Key.all);
-      end if;
+      return (if Key = null then 0 else Hash (Key.all));
    end Hash;
 
    ----------

--- a/src/gprbind.adb
+++ b/src/gprbind.adb
@@ -603,16 +603,11 @@ begin
 
    Gnatbind_Options.Append (Dash_x);
 
-   if Is_Absolute_Path (GNATBIND.all) then
-      FULL_GNATBIND := GNATBIND;
-
-   else
-      FULL_GNATBIND :=
-        new String'
-              (Dir_Name (Ada_Compiler_Path.all) &
-               Directory_Separator &
-               GNATBIND.all);
-   end if;
+   FULL_GNATBIND :=
+     (if Is_Absolute_Path (GNATBIND.all) then GNATBIND
+      else new String'
+          (Dir_Name (Ada_Compiler_Path.all) & Directory_Separator &
+           GNATBIND.all));
 
    if Gnatbind_Path_Specified then
       FULL_GNATBIND := Gnatbind_Path;

--- a/src/gprbuild-compile.adb
+++ b/src/gprbuild-compile.adb
@@ -407,11 +407,9 @@ package body Gprbuild.Compile is
                         Simple_Name => not Opt.Verbose_Mode);
 
                      if not Opt.Quiet_Output then
-                        if Opt.Verbose_Mode then
-                           Put (Exec_Path.all);
-                        else
-                           Put (Exec_Name);
-                        end if;
+                        Put
+                          ((if Opt.Verbose_Mode then Exec_Path.all
+                            else Exec_Name));
 
                         Put (" ");
 
@@ -2876,12 +2874,9 @@ package body Gprbuild.Compile is
                for Opt of Compilation_Options loop
                   Add_Str_To_Name_Buffer (" ");
 
-                  if Opt.Simple_Name then
-                     Add_Str_To_Name_Buffer (Base_Name (Opt.Name));
-
-                  else
-                     Add_Str_To_Name_Buffer (Opt.Name);
-                  end if;
+                  Add_Str_To_Name_Buffer
+                    ((if Opt.Simple_Name then Base_Name (Opt.Name)
+                      else Opt.Name));
                end loop;
 
                Put_Line (Name_Buffer (1 .. Name_Len));
@@ -3446,11 +3441,10 @@ package body Gprbuild.Compile is
                --  Record the last recorded option index, to be able to
                --  write the switches file later.
 
-               if Id.Language.Config.Object_Generated then
-                  Last_Switches_For_File := Compilation_Options.Last_Index;
-               else
-                  Last_Switches_For_File := -1;
-               end if;
+               Last_Switches_For_File :=
+                 (if Id.Language.Config.Object_Generated then
+                    Compilation_Options.Last_Index
+                  else -1);
 
                Add_Dependency_Options (Id);
                Set_Env_For_Include_Dirs (Id, Source_Project);

--- a/src/gprbuild-link.adb
+++ b/src/gprbuild-link.adb
@@ -788,13 +788,9 @@ package body Gprbuild.Link is
 
          --  Start with the minimal options
 
-         if First_Object = Objects.First_Index then
-            --  Creation of a new archive
-            Arguments.Append_Vector (Archive_Builder_Opts);
-         else
-            --  Append objects to an existing archive
-            Arguments.Append_Vector (Archive_Builder_Append_Opts);
-         end if;
+         Arguments.Append_Vector
+           ((if First_Object = Objects.First_Index then Archive_Builder_Opts
+             else Archive_Builder_Append_Opts));
 
          --  Followed by the archive name
 
@@ -975,23 +971,18 @@ package body Gprbuild.Link is
          Name_Len := 0;
 
          if Opt.Verbose_Mode then
-            if Opt.Verbosity_Level = Opt.Low then
-               Add_Str_To_Name_Buffer
-                 (Base_Name (Path.all, Executable_Suffix.all));
-            else
-               Add_Str_To_Name_Buffer (Path.all);
-            end if;
+            Add_Str_To_Name_Buffer
+              ((if Opt.Verbosity_Level = Opt.Low then
+                  Base_Name (Path.all, Executable_Suffix.all)
+                else Path.all));
 
             for Arg of Arguments loop
                if Arg.Displayed then
                   Add_Str_To_Name_Buffer (" ");
 
-                  if Arg.Simple_Name then
-                     Add_Str_To_Name_Buffer (Base_Name (Arg.Name));
-
-                  else
-                     Add_Str_To_Name_Buffer (Arg.Name);
-                  end if;
+                  Add_Str_To_Name_Buffer
+                    ((if Arg.Simple_Name then Base_Name (Arg.Name)
+                      else Arg.Name));
 
                elsif Display_Ellipse then
                   Add_Str_To_Name_Buffer (" ...");
@@ -1069,14 +1060,11 @@ package body Gprbuild.Link is
       --  Start of processing for Get_Linker_Options
 
    begin
-      if For_Project.Config.Linker_Lib_Dir_Option = No_Name then
-         Linker_Lib_Dir_Option := new String'("-L");
-
-      else
-         Linker_Lib_Dir_Option :=
-           new String'
-             (Get_Name_String (For_Project.Config.Linker_Lib_Dir_Option));
-      end if;
+      Linker_Lib_Dir_Option :=
+        (if For_Project.Config.Linker_Lib_Dir_Option = No_Name then
+           new String'("-L")
+         else new String'
+             (Get_Name_String (For_Project.Config.Linker_Lib_Dir_Option)));
 
       Linker_Opts.Clear;
 
@@ -2547,21 +2535,13 @@ package body Gprbuild.Link is
                      Library_Dirs.Set
                        (Library_Projs (J).Proj.Library_Dir.Name, True);
 
-                     if Main_Proj.Config.Linker_Lib_Dir_Option = No_Name then
-                        Add_To_Other_Arguments
-                          ("-L"
-                           & Get_Name_String
-                               (Library_Projs
-                                  (J).Proj.Library_Dir.Display_Name));
-
-                     else
-                        Add_To_Other_Arguments
-                          (Get_Name_String
-                             (Main_Proj.Config.Linker_Lib_Dir_Option)
-                           & Get_Name_String
-                               (Library_Projs
-                                  (J).Proj.Library_Dir.Display_Name));
-                     end if;
+                     Add_To_Other_Arguments
+                       ((if Main_Proj.Config.Linker_Lib_Dir_Option = No_Name
+                         then "-L"
+                         else Get_Name_String
+                             (Main_Proj.Config.Linker_Lib_Dir_Option)) &
+                        Get_Name_String
+                          (Library_Projs (J).Proj.Library_Dir.Display_Name));
 
                      if Opt.Run_Path_Option
                        and then
@@ -2575,18 +2555,12 @@ package body Gprbuild.Link is
                      end if;
                   end if;
 
-                  if Main_Proj.Config.Linker_Lib_Name_Option = No_Name then
-                     Add_To_Other_Arguments
-                       ("-l" & Get_Name_String
-                                 (Library_Projs (J).Proj.Library_Name));
-
-                  else
-                     Add_To_Other_Arguments
-                       (Get_Name_String
-                          (Main_Proj.Config.Linker_Lib_Name_Option)
-                        & Get_Name_String
-                            (Library_Projs (J).Proj.Library_Name));
-                  end if;
+                  Add_To_Other_Arguments
+                    ((if Main_Proj.Config.Linker_Lib_Name_Option = No_Name then
+                        "-l"
+                      else Get_Name_String
+                          (Main_Proj.Config.Linker_Lib_Name_Option)) &
+                     Get_Name_String (Library_Projs (J).Proj.Library_Name));
                end if;
             end if;
          end loop;
@@ -3238,11 +3212,10 @@ package body Gprbuild.Link is
                end loop;
 
                if Arg_Length > Main_Proj.Config.Max_Command_Line_Length then
-                  if Main_Proj.Config.Resp_File_Options = No_Name_List then
-                     Min_Number_Of_Objects := 0;
-                  else
-                     Min_Number_Of_Objects := 1;
-                  end if;
+                  Min_Number_Of_Objects :=
+                    (if Main_Proj.Config.Resp_File_Options = No_Name_List then
+                       0
+                     else 1);
 
                   --  Don't create a response file if there would not be
                   --  a smaller number of arguments.

--- a/src/gprbuild-main.adb
+++ b/src/gprbuild-main.adb
@@ -268,11 +268,8 @@ procedure Gprbuild.Main is
       Success : Boolean;
    begin
       if For_Builder then
-         if Has_Global_Compilation_Switches then
-            Builder_Switches_Lang := No_Name;
-         else
-            Builder_Switches_Lang := For_Lang;
-         end if;
+         Builder_Switches_Lang :=
+           (if Has_Global_Compilation_Switches then No_Name else For_Lang);
 
          Scan_Arg
            (Switch,
@@ -916,13 +913,10 @@ procedure Gprbuild.Main is
                Script_Name : constant String :=
                  Arg (Build_Script_Option'Length + 1 .. Arg'Last);
             begin
-               if Is_Absolute_Path (Script_Name) then
-                  Build_Script_Name := new String'(Script_Name);
-
-               else
-                  Build_Script_Name :=
-                    new String'(Get_Current_Dir & Script_Name);
-               end if;
+               Build_Script_Name :=
+                 (if Is_Absolute_Path (Script_Name) then
+                    new String'(Script_Name)
+                  else new String'(Get_Current_Dir & Script_Name));
             end;
 
          elsif Arg = "--db-" then
@@ -1145,18 +1139,15 @@ procedure Gprbuild.Main is
          then
             Forbidden_In_Package_Builder;
 
-            if Arg'Length = Relocate_Build_Tree_Option'Length then
-               Build_Tree_Dir := new String'(Current_Working_Dir);
-
-            else
-               Build_Tree_Dir :=
-                 new String'
+            Build_Tree_Dir :=
+              (if Arg'Length = Relocate_Build_Tree_Option'Length then
+                 new String'(Current_Working_Dir)
+               else new String'
                    (Normalize_Pathname
                       (Arg (Relocate_Build_Tree_Option'Length + 2 .. Arg'Last),
                        Current_Working_Dir,
                        Resolve_Links => Opt.Follow_Links_For_Dirs) &
-                    Dir_Separator);
-            end if;
+                    Dir_Separator));
 
             --  Out-of-tree compilation also imply -p (create missing dirs)
 

--- a/src/gprbuild-post_compile.adb
+++ b/src/gprbuild-post_compile.adb
@@ -829,14 +829,10 @@ package body Gprbuild.Post_Compile is
                         --  directory, for other projects, use the
                         --  object directory.
 
-                        if ALI_Project.Library and then not From_Object_Dir
-                        then
-                           Get_Name_String
-                             (ALI_Project.Library_ALI_Dir.Display_Name);
-                        else
-                           Get_Name_String
-                             (ALI_Project.Object_Directory.Display_Name);
-                        end if;
+                        Get_Name_String
+                          ((if ALI_Project.Library and then not From_Object_Dir
+                            then ALI_Project.Library_ALI_Dir.Display_Name
+                            else ALI_Project.Object_Directory.Display_Name));
 
                         Add_Str_To_Name_Buffer (ALI);
 
@@ -1875,15 +1871,14 @@ package body Gprbuild.Post_Compile is
                      Elem := Project_Tree.Shared.String_Elements.Table (List);
                      Get_Name_String (Elem.Value);
 
-                     if Is_Absolute_Path (Name_Buffer (1 .. Name_Len)) then
-                        OK := Is_Regular_File (Name_Buffer (1 .. Name_Len));
-
-                     else
-                        OK := Is_Regular_File
-                          (Get_Name_String (For_Project.Object_Directory.Name)
-                           & Directory_Separator
-                           & Name_Buffer (1 .. Name_Len));
-                     end if;
+                     OK :=
+                       (if Is_Absolute_Path (Name_Buffer (1 .. Name_Len)) then
+                          Is_Regular_File (Name_Buffer (1 .. Name_Len))
+                        else Is_Regular_File
+                            (Get_Name_String
+                               (For_Project.Object_Directory.Name) &
+                             Directory_Separator &
+                             Name_Buffer (1 .. Name_Len)));
 
                      if not OK then
                         Error_Msg
@@ -2428,11 +2423,10 @@ package body Gprbuild.Post_Compile is
             begin
                Next_Proj := For_Project.Extends;
 
-               if For_Project.Qualifier = Aggregate_Library then
-                  Iter := For_Each_Source (Project_Tree);
-               else
-                  Iter := For_Each_Source (Project_Tree, For_Project);
-               end if;
+               Iter :=
+                 (if For_Project.Qualifier = Aggregate_Library then
+                    For_Each_Source (Project_Tree)
+                  else For_Each_Source (Project_Tree, For_Project));
 
                loop
                   while GPR.Element (Iter) /= No_Source
@@ -2537,11 +2531,10 @@ package body Gprbuild.Post_Compile is
          begin
             Next_Proj := For_Project.Extends;
 
-            if For_Project.Qualifier = Aggregate_Library then
-               Iter := For_Each_Source (Project_Tree);
-            else
-               Iter := For_Each_Source (Project_Tree, For_Project);
-            end if;
+            Iter :=
+              (if For_Project.Qualifier = Aggregate_Library then
+                 For_Each_Source (Project_Tree)
+               else For_Each_Source (Project_Tree, For_Project));
 
             loop
                --  Look for the Source_Id corresponding to this unit
@@ -3772,12 +3765,11 @@ package body Gprbuild.Post_Compile is
 
          if Roots = null then
             if Main_Source.Unit = No_Unit_Index then
-               if Main_Project.Qualifier = Aggregate_Library then
-                  Iter := For_Each_Source (Project_Tree);
-               else
-                  Iter := For_Each_Source
-                    (Project_Tree, Encapsulated_Libs => False);
-               end if;
+               Iter :=
+                 (if Main_Project.Qualifier = Aggregate_Library then
+                    For_Each_Source (Project_Tree)
+                  else For_Each_Source
+                      (Project_Tree, Encapsulated_Libs => False));
 
                while GPR.Element (Iter) /= No_Source loop
                   Initialize_Source_Record (GPR.Element (Iter));
@@ -3872,15 +3864,14 @@ package body Gprbuild.Post_Compile is
          begin
             Position := Projects.Find (Project.Path.Display_Name);
 
-            if Project_File_Paths.Has_Element (Position)
-              and then Project_File_Paths.Element (Position).Line (1)
-              /= ASCII.NUL
-            then
-               return Project_File_Paths.Element (Position).Line;
-            end if;
-
-            return String (Osint.File_Stamp (Project.Path.Display_Name)) & ' '
-              & Get_Project_Checksum (Project);
+            return
+              (if
+                 Project_File_Paths.Has_Element (Position)
+                 and then Project_File_Paths.Element (Position).Line (1) /=
+                   ASCII.NUL
+               then Project_File_Paths.Element (Position).Line
+               else String (Osint.File_Stamp (Project.Path.Display_Name)) &
+                 ' ' & Get_Project_Checksum (Project));
          end Get_Project_Checkline;
 
       begin
@@ -4255,17 +4246,13 @@ package body Gprbuild.Post_Compile is
                         while Proj /= No_Project loop
                            Name_Len := 0;
 
-                           if Proj.Library
-                             and then
-                               Proj.Library_ALI_Dir /= No_Path_Information
-                           then
-                              Get_Name_String_And_Append
-                                (Proj.Library_ALI_Dir.Display_Name);
-
-                           else
-                              Get_Name_String_And_Append
-                                (Proj.Object_Directory.Display_Name);
-                           end if;
+                           Get_Name_String_And_Append
+                             ((if
+                                 Proj.Library
+                                 and then Proj.Library_ALI_Dir /=
+                                   No_Path_Information
+                               then Proj.Library_ALI_Dir.Display_Name
+                               else Proj.Object_Directory.Display_Name));
 
                            Add_Char_To_Name_Buffer
                              (Directory_Separator);

--- a/src/gprbuild.adb
+++ b/src/gprbuild.adb
@@ -159,12 +159,9 @@ package body Gprbuild is
 
    function Archive_Suffix (For_Project : Project_Id) return String is
    begin
-      if For_Project.Config.Archive_Suffix = No_File then
-         return ".a";
-
-      else
-         return Get_Name_String (For_Project.Config.Archive_Suffix);
-      end if;
+      return
+        (if For_Project.Config.Archive_Suffix = No_File then ".a"
+         else Get_Name_String (For_Project.Config.Archive_Suffix));
    end Archive_Suffix;
 
    -------------------
@@ -496,11 +493,8 @@ package body Gprbuild is
          Put (' ');
          Put (Name);
 
-         if Outstanding_Processes <= 1 then
-            Put_Line (" process");
-         else
-            Put_Line (" processes");
-         end if;
+         Put_Line
+           ((if Outstanding_Processes <= 1 then " process" else " processes"));
       end if;
    end Display_Processes;
 

--- a/src/gprclean-main.adb
+++ b/src/gprclean-main.adb
@@ -535,12 +535,9 @@ procedure Gprclean.Main is
                        (Switch (Relocate_Build_Tree_Option'Length + 2
                         .. Switch'Last));
                   begin
-                     if Is_Absolute_Path (Dir) then
-                        Build_Tree_Dir := new String'(Dir);
-                     else
-                        Build_Tree_Dir :=
-                          new String'(Get_Current_Dir & Dir);
-                     end if;
+                     Build_Tree_Dir :=
+                       (if Is_Absolute_Path (Dir) then new String'(Dir)
+                        else new String'(Get_Current_Dir & Dir));
                   end;
                end if;
 
@@ -654,15 +651,10 @@ procedure Gprclean.Main is
                declare
                   Prj : constant String := Switch (3 .. Switch'Last);
                begin
-                  if Prj'Length > 1
-                    and then Prj (Prj'First) = '='
-                  then
-                     Project_File_Name :=
-                       new String'
-                         (Prj (Prj'First + 1 ..  Prj'Last));
-                  else
-                     Project_File_Name := new String'(Prj);
-                  end if;
+                  Project_File_Name :=
+                    (if Prj'Length > 1 and then Prj (Prj'First) = '=' then
+                       new String'(Prj (Prj'First + 1 .. Prj'Last))
+                     else new String'(Prj));
                end;
 
             else
@@ -1063,10 +1055,8 @@ begin
    if Verbose_Mode and (not File_Deleted) then
       New_Line;
 
-      if Do_Nothing then
-         Put_Line ("No file needs to be deleted");
-      else
-         Put_Line ("No file has been deleted");
-      end if;
+      Put_Line
+        ((if Do_Nothing then "No file needs to be deleted"
+          else "No file has been deleted"));
    end if;
 end Gprclean.Main;

--- a/src/gprclean.adb
+++ b/src/gprclean.adb
@@ -434,11 +434,10 @@ package body Gprclean is
                            Proj     : Project_Id := Project;
                         begin
                            Project_Loop : loop
-                              if Proj.Qualifier = Aggregate_Library then
-                                 Iter := For_Each_Source (Project_Tree);
-                              else
-                                 Iter := For_Each_Source (Project_Tree, Proj);
-                              end if;
+                              Iter :=
+                                (if Proj.Qualifier = Aggregate_Library then
+                                   For_Each_Source (Project_Tree)
+                                 else For_Each_Source (Project_Tree, Proj));
 
                               loop
                                  Source := GPR.Element (Iter);

--- a/src/gprconfig-main.adb
+++ b/src/gprconfig-main.adb
@@ -284,11 +284,9 @@ procedure GprConfig.Main is
          Put_Line (" with the following command line:");
          Put ("gprconfig --batch");
          Put (" --target=");
-         if Selected_Target = Null_Unbounded_String then
-            Put ("all");
-         else
-            Put (To_String (Selected_Target));
-         end if;
+         Put
+           ((if Selected_Target = Null_Unbounded_String then "all"
+             else To_String (Selected_Target)));
 
          C := First (Compilers);
          while Has_Element (C) loop
@@ -607,16 +605,15 @@ begin
                      Last := Last - 1;
                   end if;
 
-                  if Last - RTS'First > 6 and then
-                    RTS (Last - 5 .. Last) = "adalib" and then
-                    (RTS (Last - 6) = Directory_Separator or else
-                     (RTS (Last - 6) = '/'))
-
-                  then
-                     Last := Last - 6;
-                  else
-                     Last := RTS'Last;
-                  end if;
+                  Last :=
+                    (if
+                       Last - RTS'First > 6
+                       and then RTS (Last - 5 .. Last) = "adalib"
+                       and then
+                       (RTS (Last - 6) = Directory_Separator
+                        or else (RTS (Last - 6) = '/'))
+                     then Last - 6
+                     else RTS'Last);
 
                   Parse_Knowledge_Base (Base, RTS (RTS'First .. Last));
                end;

--- a/src/gprexch.adb
+++ b/src/gprexch.adb
@@ -34,12 +34,9 @@ package body Gprexch is
 
    function Binding_Label (Section : Binding_Section) return String is
    begin
-      if Binding_Labels (Section) = null then
-         return "";
-
-      else
-         return Binding_Labels (Section).all;
-      end if;
+      return
+        (if Binding_Labels (Section) = null then ""
+         else Binding_Labels (Section).all);
    end Binding_Label;
 
    -------------------------
@@ -82,12 +79,9 @@ package body Gprexch is
 
    function Library_Label (Section : Library_Section) return String is
    begin
-      if Library_Labels (Section) = null then
-         return "";
-
-      else
-         return Library_Labels (Section).all;
-      end if;
+      return
+        (if Library_Labels (Section) = null then ""
+         else Library_Labels (Section).all);
    end Library_Label;
 
 --  Package elaboration code (build the lists of section labels)

--- a/src/gprinstall-db.adb
+++ b/src/gprinstall-db.adb
@@ -95,11 +95,10 @@ package body Gprinstall.DB is
 
       function Project_Dir return String is
       begin
-         if Is_Absolute_Path (Global_Project_Subdir.V.all) then
-            return Global_Project_Subdir.V.all;
-         else
-            return Global_Prefix_Dir.V.all & Global_Project_Subdir.V.all;
-         end if;
+         return
+           (if Is_Absolute_Path (Global_Project_Subdir.V.all) then
+              Global_Project_Subdir.V.all
+            else Global_Prefix_Dir.V.all & Global_Project_Subdir.V.all);
       end Project_Dir;
 
       package File_Size_IO is new Text_IO.Integer_IO (Directories.File_Size);
@@ -125,11 +124,7 @@ package body Gprinstall.DB is
             --  Number of files
 
             Put (S.N_Files, Width => 5);
-            if S.N_Files > 1 then
-               Put (" files, ");
-            else
-               Put (" file, ");
-            end if;
+            Put ((if S.N_Files > 1 then " files, " else " file, "));
 
             --  Sizes
 

--- a/src/gprinstall-install.adb
+++ b/src/gprinstall-install.adb
@@ -488,11 +488,7 @@ package body Gprinstall.Install is
                                       To_Lower
                                         (Get_Name_String (V.Value.Value));
                            begin
-                              if Val = "false" then
-                                 Active := False;
-                              else
-                                 Active := True;
-                              end if;
+                              Active := Val /= "false";
                            end;
 
                         elsif V.Name = Name_Side_Debug then
@@ -501,11 +497,7 @@ package body Gprinstall.Install is
                                       To_Lower
                                         (Get_Name_String (V.Value.Value));
                            begin
-                              if Val = "true" then
-                                 Side_Debug := True;
-                              else
-                                 Side_Debug := False;
-                              end if;
+                              Side_Debug := Val = "true";
                            end;
 
                         elsif V.Name = Name_Install_Project then
@@ -514,11 +506,7 @@ package body Gprinstall.Install is
                                       To_Lower
                                         (Get_Name_String (V.Value.Value));
                            begin
-                              if Val = "false" then
-                                 Install_Project := False;
-                              else
-                                 Install_Project := True;
-                              end if;
+                              Install_Project := Val /= "false";
                            end;
 
                         end if;
@@ -604,11 +592,10 @@ package body Gprinstall.Install is
          begin
             --  .default is always omitted from the directory name
 
-            if Suffix and then Build_Name.all /= "default" then
-               return '.' & Build_Name.all;
-            else
-               return "";
-            end if;
+            return
+              (if Suffix and then Build_Name.all /= "default" then
+                 '.' & Build_Name.all
+               else "");
          end Get_Suffix;
 
       begin
@@ -680,11 +667,7 @@ package body Gprinstall.Install is
                                       To_Lower
                                         (Get_Name_String (V.Value.Value));
                            begin
-                              if Val = "false" then
-                                 return False;
-                              else
-                                 return True;
-                              end if;
+                              return Val /= "false";
                            end;
                         end if;
                      end;
@@ -718,11 +701,9 @@ package body Gprinstall.Install is
 
          function Get_Exec_Suffix return String is
          begin
-            if Project.Config.Executable_Suffix = No_Name then
-               return "";
-            else
-               return Get_Name_String (Project.Config.Executable_Suffix);
-            end if;
+            return
+              (if Project.Config.Executable_Suffix = No_Name then ""
+               else Get_Name_String (Project.Config.Executable_Suffix));
          end Get_Exec_Suffix;
 
          Builder_Package  : constant Package_Id :=
@@ -803,11 +784,9 @@ package body Gprinstall.Install is
 
       function Exec_Dir return String is
       begin
-         if Is_Absolute_Path (Exec_Subdir.V.all) then
-            return Exec_Subdir.V.all;
-         else
-            return Prefix_Dir.V.all & Exec_Subdir.V.all;
-         end if;
+         return
+           (if Is_Absolute_Path (Exec_Subdir.V.all) then Exec_Subdir.V.all
+            else Prefix_Dir.V.all & Exec_Subdir.V.all);
       end Exec_Dir;
 
       -------------
@@ -839,11 +818,10 @@ package body Gprinstall.Install is
 
       function Link_Lib_Dir return String is
       begin
-         if Is_Absolute_Path (Link_Lib_Subdir.V.all) then
-            return Link_Lib_Subdir.V.all;
-         else
-            return Prefix_Dir.V.all & Link_Lib_Subdir.V.all;
-         end if;
+         return
+           (if Is_Absolute_Path (Link_Lib_Subdir.V.all) then
+              Link_Lib_Subdir.V.all
+            else Prefix_Dir.V.all & Link_Lib_Subdir.V.all);
       end Link_Lib_Dir;
 
       -----------------
@@ -875,11 +853,10 @@ package body Gprinstall.Install is
 
       function Project_Dir return String is
       begin
-         if Is_Absolute_Path (Project_Subdir.V.all) then
-            return Project_Subdir.V.all;
-         else
-            return Prefix_Dir.V.all & Project_Subdir.V.all;
-         end if;
+         return
+           (if Is_Absolute_Path (Project_Subdir.V.all) then
+              Project_Subdir.V.all
+            else Prefix_Dir.V.all & Project_Subdir.V.all);
       end Project_Dir;
 
       ---------
@@ -924,11 +901,7 @@ package body Gprinstall.Install is
          end if;
 
          if Dry_Run or else Opt.Verbose_Mode then
-            if Sym_Link then
-               Put ("ln -s ");
-            else
-               Put ("cp ");
-            end if;
+            Put ((if Sym_Link then "ln -s " else "cp "));
 
             Put (From);
             Put (" ");
@@ -972,11 +945,9 @@ package body Gprinstall.Install is
             then
                if Create_Dest_Dir then
                   begin
-                     if Sym_Link then
-                        Create_Path (Containing_Directory (From));
-                     else
-                        Create_Path (To);
-                     end if;
+                     Create_Path
+                       ((if Sym_Link then Containing_Directory (From)
+                         else To));
                   exception
                      when Text_IO.Use_Error =>
                         --  Cannot create path, permission issue
@@ -1198,12 +1169,10 @@ package body Gprinstall.Install is
             Sid  : Source_Id;
 
          begin
-            if Project.Qualifier = Aggregate_Library then
-               Iter := For_Each_Source (Tree, Locally_Removed => False);
-            else
-               Iter := For_Each_Source
-                 (Tree, Project, Locally_Removed => False);
-            end if;
+            Iter :=
+              (if Project.Qualifier = Aggregate_Library then
+                 For_Each_Source (Tree, Locally_Removed => False)
+               else For_Each_Source (Tree, Project, Locally_Removed => False));
 
             loop
                Sid := Element (Iter);
@@ -1261,14 +1230,13 @@ package body Gprinstall.Install is
                            Proj : Project_Id := Sid.Project;
                            Ssid : Source_Id;
                         begin
-                           if Other_Part (Sid) = null
-                             or else Sid.Naming_Exception = No
-                             or else All_Sources
-                           then
-                              Ssid := Sid;
-                           else
-                              Ssid := Other_Part (Sid);
-                           end if;
+                           Ssid :=
+                             (if
+                                Other_Part (Sid) = null
+                                or else Sid.Naming_Exception = No
+                                or else All_Sources
+                              then Sid
+                              else Other_Part (Sid));
 
                            if Project.Qualifier = Aggregate_Library then
                               Proj := Project;
@@ -1413,11 +1381,9 @@ package body Gprinstall.Install is
                   K := K - 1;
                end loop;
 
-               if K = 0 then
-                  return Pathname;
-               else
-                  return Pathname (K + 1 .. Pathname'Last);
-               end if;
+               return
+                 (if K = 0 then Pathname
+                  else Pathname (K + 1 .. Pathname'Last));
             end Get_Pattern;
 
          begin
@@ -1985,11 +1951,9 @@ package body Gprinstall.Install is
 
             --  Project objects and/or library
 
-            if Project.Library then
-               Line := +"         for Library_Dir use """;
-            else
-               Line := +"         for Object_Dir use """;
-            end if;
+            Line :=
+              (if Project.Library then +"         for Library_Dir use """
+               else +"         for Object_Dir use """);
 
             Line := Line
               & Relative_Path
@@ -2200,12 +2164,10 @@ package body Gprinstall.Install is
          function Image (Id : Variable_Id) return String is
             V : constant Variable_Value := Vels (Id).Value;
          begin
-            if V.Default then
-               return "";
-            else
-               return "for " & Get_Name_String (Vels (Id).Name) & " use "
-                 & Image (V);
-            end if;
+            return
+              (if V.Default then ""
+               else "for " & Get_Name_String (Vels (Id).Name) & " use " &
+                 Image (V));
          end Image;
 
          function Image (Var : Variable_Value) return String is
@@ -2587,11 +2549,8 @@ package body Gprinstall.Install is
             Put ("Project ");
             Put (Filename);
 
-            if Dry_Run then
-               Put_Line (" would be installed");
-            else
-               Put_Line (" installed");
-            end if;
+            Put_Line
+              ((if Dry_Run then " would be installed" else " installed"));
 
             New_Line;
          end if;
@@ -2840,11 +2799,9 @@ package body Gprinstall.Install is
             if Project.Library then
                Line := +"library ";
             else
-               if Has_Sources (Project) then
-                  Line := +"standard ";
-               else
-                  Line := +"abstract ";
-               end if;
+               Line :=
+                 (if Has_Sources (Project) then +"standard "
+                  else +"abstract ");
             end if;
 
             Line := Line & "project ";

--- a/src/gprinstall-main.adb
+++ b/src/gprinstall-main.adb
@@ -371,14 +371,12 @@ procedure Gprinstall.Main is
                Set_Param (Global_Project_Subdir, Project_Subdir_Option);
 
             elsif Has_Prefix (Build_Var_Option) then
-               if Build_Vars = null then
-                  Build_Vars := new String'
-                    (Arg (Build_Var_Option'Length + 2 .. Arg'Last));
-               else
-                  Build_Vars := new String'
-                    ((Arg (Build_Var_Option'Length + 2 .. Arg'Last))
-                     & ',' & Build_Vars.all);
-               end if;
+               Build_Vars :=
+                 (if Build_Vars = null then
+                    new String'(Arg (Build_Var_Option'Length + 2 .. Arg'Last))
+                  else new String'
+                      ((Arg (Build_Var_Option'Length + 2 .. Arg'Last)) & ',' &
+                       Build_Vars.all));
 
             elsif Has_Prefix (No_Build_Var_Option) then
                No_Build_Var := True;
@@ -451,11 +449,9 @@ procedure Gprinstall.Main is
                                (Arg (Relocate_Build_Tree_Option'Length + 2
                                      .. Arg'Last));
                   begin
-                     if Is_Absolute_Path (Dir) then
-                        Build_Tree_Dir := new String'(Dir);
-                     else
-                        Build_Tree_Dir := new String'(Get_Current_Dir & Dir);
-                     end if;
+                     Build_Tree_Dir :=
+                       (if Is_Absolute_Path (Dir) then new String'(Dir)
+                        else new String'(Get_Current_Dir & Dir));
                   end;
                end if;
 
@@ -1009,14 +1005,12 @@ begin
       DB.List;
 
    else
-      if Global_Install_Name.Default then
-         Uninstall.Process
-           (Ada.Directories.Compose
+      Uninstall.Process
+        ((if Global_Install_Name.Default then
+            Ada.Directories.Compose
               (Ada.Directories.Containing_Directory (Project_File_Name.all),
-               Ada.Directories.Base_Name (Project_File_Name.all)));
-      else
-         Uninstall.Process (Global_Install_Name.V.all);
-      end if;
+               Ada.Directories.Base_Name (Project_File_Name.all))
+          else Global_Install_Name.V.all));
    end if;
 
    if Usage_Mode = Install_Mode then

--- a/src/gprinstall-uninstall.adb
+++ b/src/gprinstall-uninstall.adb
@@ -94,11 +94,10 @@ package body Gprinstall.Uninstall is
             return Containing_Directory (Containing_Directory (Install_Name));
 
          else
-            if Is_Absolute_Path (Global_Project_Subdir.V.all) then
-               return Global_Project_Subdir.V.all;
-            else
-               return Global_Prefix_Dir.V.all & Global_Project_Subdir.V.all;
-            end if;
+            return
+              (if Is_Absolute_Path (Global_Project_Subdir.V.all) then
+                 Global_Project_Subdir.V.all
+               else Global_Prefix_Dir.V.all & Global_Project_Subdir.V.all);
          end if;
       end Project_Dir;
 
@@ -175,13 +174,11 @@ package body Gprinstall.Uninstall is
                end if;
 
                if Global_Prefix_Dir.Default then
-                  if Prefix = Null_Unbounded_String then
-                     Prefix := To_Unbounded_String
-                       (Normalize_Pathname (Pathname));
-                  else
-                     Prefix := To_Unbounded_String
-                       (Common_Prefix (To_String (Prefix), Pathname));
-                  end if;
+                  Prefix :=
+                    (if Prefix = Null_Unbounded_String then
+                       To_Unbounded_String (Normalize_Pathname (Pathname))
+                     else To_Unbounded_String
+                         (Common_Prefix (To_String (Prefix), Pathname)));
                end if;
 
                --  Unconditionally add a file to the remove list if digest is

--- a/src/gprlib-build_shared_lib.adb
+++ b/src/gprlib-build_shared_lib.adb
@@ -459,14 +459,9 @@ begin
          end if;
       end if;
 
-      if Is_Absolute_Path (Library_Version.all) then
-         Library_Version_Path := Library_Version;
-
-      else
-         Library_Version_Path :=
-           new String'
-             (Library_Directory.all & Library_Version.all);
-      end if;
+      Library_Version_Path :=
+        (if Is_Absolute_Path (Library_Version.all) then Library_Version
+         else new String'(Library_Directory.all & Library_Version.all));
 
       --  Now that the table has been filled, call Build
 

--- a/src/gprlib.adb
+++ b/src/gprlib.adb
@@ -914,11 +914,9 @@ procedure Gprlib is
 
          --  Make sure that the init procedure is never "adainit"
 
-         if Library_Name.all = "ada" then
-            Bind_Options.Append ("-Lada_");
-         else
-            Bind_Options.Append ("-L" & Library_Name.all);
-         end if;
+         Bind_Options.Append
+           ((if Library_Name.all = "ada" then "-Lada_"
+             else "-L" & Library_Name.all));
 
          if Auto_Init and then SALs_Use_Constructors then
             --  Check that pragma Linker_Constructor is supported
@@ -1643,11 +1641,10 @@ procedure Gprlib is
             --  of the archive, only put on the command line a number of
             --  character lower that Maximum_Size.
 
-            if First_AB_Object_Pos > AB_Objects.First_Index then
-               AB_Options := AB_Append_Options;
-            else
-               AB_Options := AB_Create_Options;
-            end if;
+            AB_Options :=
+              (if First_AB_Object_Pos > AB_Objects.First_Index then
+                 AB_Append_Options
+               else AB_Create_Options);
 
             AB_Options.Append (Library_Path_Name.all);
 

--- a/src/gprls-main.adb
+++ b/src/gprls-main.adb
@@ -184,18 +184,14 @@ procedure Gprls.Main is
             New_Line;
 
             if Status = Incomplete_Closure then
-               if The_Sources.Last_Index = 1 then
-                  Put_Line ("Incomplete closure:");
-               else
-                  Put_Line ("Incomplete closures:");
-               end if;
+               Put_Line
+                 ((if The_Sources.Last_Index = 1 then "Incomplete closure:"
+                   else "Incomplete closures:"));
 
             elsif Status = GPR.Util.Success then
-               if The_Sources.Last_Index = 1 then
-                  Put_Line ("Closure:");
-               else
-                  Put_Line ("Closures:");
-               end if;
+               Put_Line
+                 ((if The_Sources.Last_Index = 1 then "Closure:"
+                   else "Closures:"));
 
             else
                Fail_Program
@@ -260,22 +256,18 @@ procedure Gprls.Main is
                        (Units.Table (ALIs.Table (Id).First_Unit).Uname);
 
                      if Print_Object then
-                        if ALIs.Table (Id).No_Object then
-                           Output_Object (No_File);
-                        else
-                           Output_Object (ALIs.Table (Id).Ofile_Full_Name);
-                        end if;
+                        Output_Object
+                          ((if ALIs.Table (Id).No_Object then No_File
+                            else ALIs.Table (Id).Ofile_Full_Name));
                      end if;
 
                      --  In verbose mode print all main units in the ALI file,
                      --  otherwise just print the first one to ease columnwise
                      --  printout.
 
-                     if Verbose_Mode then
-                        Last_U := ALIs.Table (Id).Last_Unit;
-                     else
-                        Last_U := ALIs.Table (Id).First_Unit;
-                     end if;
+                     Last_U :=
+                       (if Verbose_Mode then ALIs.Table (Id).Last_Unit
+                        else ALIs.Table (Id).First_Unit);
 
                      for U in ALIs.Table (Id).First_Unit .. Last_U loop
                         if Print_Unit then
@@ -506,11 +498,9 @@ procedure Gprls.Main is
    function Get_Tree_Name (Index : Positive) return String is
       Tree : constant Project_Tree_Ref := File_Names (Index).Tree;
    begin
-      if Tree = null then
-         return "";
-      else
-         return Get_Name_String (Tree.Projects.Project.Name);
-      end if;
+      return
+        (if Tree = null then ""
+         else Get_Name_String (Tree.Projects.Project.Name));
    end Get_Tree_Name;
 
    ----------------------
@@ -1332,11 +1322,9 @@ begin
      String (1 .. Project_File_Name'Length + Project_File_Extension'Length);
    Path_Last := Project_File_Name'Length;
 
-   if File_Names_Case_Sensitive then
-      Path_Name (1 .. Path_Last) := Project_File_Name.all;
-   else
-      Path_Name (1 .. Path_Last) := To_Lower (Project_File_Name.all);
-   end if;
+   Path_Name (1 .. Path_Last) :=
+     (if File_Names_Case_Sensitive then Project_File_Name.all
+      else To_Lower (Project_File_Name.all));
 
    Path_Name (Path_Last + 1 .. Path_Name'Last) :=
      Project_File_Extension;

--- a/src/gprls.adb
+++ b/src/gprls.adb
@@ -173,11 +173,9 @@ package body Gprls is
       if ALI = No_ALI_Id then
          Status := Not_Found;
       else
-         if Source.Kind = Spec then
-            U := ALIs.Table (ALI).Last_Unit;
-         else
-            U := ALIs.Table (ALI).First_Unit;
-         end if;
+         U :=
+           (if Source.Kind = Spec then ALIs.Table (ALI).Last_Unit
+            else ALIs.Table (ALI).First_Unit);
 
          Find_Status (Source, ALI, U, Status);
       end if;
@@ -267,11 +265,7 @@ package body Gprls is
    procedure Output_Object (O : File_Name_Type) is
    begin
       if Print_Object then
-         if O /= No_File then
-            Put_Line (Get_Name_String (O));
-         else
-            Put_Line (No_Obj);
-         end if;
+         Put_Line ((if O /= No_File then Get_Name_String (O) else No_Obj));
       end if;
    end Output_Object;
 
@@ -455,17 +449,11 @@ package body Gprls is
          New_Line;
          Put ("     Kind   => ");
 
-         if Units.Table (U_Id).Unit_Kind = 'p' then
-            Put ("package ");
-         else
-            Put ("subprogram ");
-         end if;
+         Put
+           ((if Units.Table (U_Id).Unit_Kind = 'p' then "package "
+             else "subprogram "));
 
-         if Kind = 's' then
-            Put_Line ("spec");
-         else
-            Put_Line ("body");
-         end if;
+         Put_Line ((if Kind = 's' then "spec" else "body"));
       end if;
 
       if Verbose_Mode then
@@ -697,11 +685,9 @@ package body Gprls is
          if ALIs.Table (A).Main_Program /= None then
             Output_Token (T_Main);
 
-            if ALIs.Table (A).Main_Program = Proc then
-               Output_Token (T_Procedure);
-            else
-               Output_Token (T_Function);
-            end if;
+            Output_Token
+              ((if ALIs.Table (A).Main_Program = Proc then T_Procedure
+                else T_Function));
 
             Write_Eol;
          end if;
@@ -863,11 +849,9 @@ package body Gprls is
 
          Output_Token (T_Kind);
 
-         if Units.Table (U).Unit_Kind = 'p' then
-            Output_Token (T_Package);
-         else
-            Output_Token (T_Subprogram);
-         end if;
+         Output_Token
+           ((if Units.Table (U).Unit_Kind = 'p' then T_Package
+             else T_Subprogram));
 
          Get_Name_String (UR.Uname);
 
@@ -959,11 +943,8 @@ package body Gprls is
 
          Get_Name_String (Withs.Table (W).Uname);
 
-         if Name_Buffer (Name_Len) = 's' then
-            Output_Token (T_Spec);
-         else
-            Output_Token (T_Body);
-         end if;
+         Output_Token
+           ((if Name_Buffer (Name_Len) = 's' then T_Spec else T_Body));
 
          Write_Eol;
 

--- a/src/gprname.adb
+++ b/src/gprname.adb
@@ -704,13 +704,10 @@ package body GPRName is
          --  If there was no comments for attribute Source_List_File, put those
          --  for Source_Files, if they exist.
 
-         if Present (Source_List_File_Comments) then
-            Tree.Project_Nodes.Table (Attribute).Comments :=
-              Source_List_File_Comments;
-         else
-            Tree.Project_Nodes.Table (Attribute).Comments :=
-              Source_Files_Comments;
-         end if;
+         Tree.Project_Nodes.Table (Attribute).Comments :=
+           (if Present (Source_List_File_Comments) then
+              Source_List_File_Comments
+            else Source_Files_Comments);
 
          --  Put the foreign source file names in the source list file
 
@@ -1667,12 +1664,10 @@ package body GPRName is
                                  Current_Source := Sources (Index);
 
                                  if Opt.Verbose_Mode then
-                                    if Current_Source.Spec then
-                                       Put ("      spec of ");
-
-                                    else
-                                       Put ("      body of ");
-                                    end if;
+                                    Put
+                                      ((if Current_Source.Spec then
+                                          "      spec of "
+                                        else "      body of "));
 
                                     Put_Line
                                       (Get_Name_String

--- a/src/gprslave.adb
+++ b/src/gprslave.adb
@@ -711,14 +711,11 @@ procedure Gprslave is
    function Get_Arg (Builder : Build_Master; Value : String) return String is
       P : constant Natural := Fixed.Index (Value, WD_Path_Tag);
    begin
-      if P = 0 then
-         return Value;
-      else
-         return Value (Value'First .. P - 1)
-           & Work_Directory (Builder)
-           & Directory_Separator
-           & Get_Arg (Builder, Value (P + WD_Path_Tag'Length .. Value'Last));
-      end if;
+      return
+        (if P = 0 then Value
+         else Value (Value'First .. P - 1) & Work_Directory (Builder) &
+           Directory_Separator &
+           Get_Arg (Builder, Value (P + WD_Path_Tag'Length .. Value'Last)));
    end Get_Arg;
 
    --------------
@@ -2024,16 +2021,11 @@ procedure Gprslave is
                if Item'Length > 0 then
                   --  No start to replace, this is a plain file-name
 
-                  if Star = 0 then
-                     Name := To_Unbounded_String (Item);
-
-                  else
-                     --  We have a star, replace it with the base name
-
-                     Name := To_Unbounded_String
-                       (Item (Item'First .. Star - 1)
-                        & Base_Name & Item (Star + 1 .. Item'Last));
-                  end if;
+                  Name :=
+                    (if Star = 0 then To_Unbounded_String (Item)
+                     else To_Unbounded_String
+                         (Item (Item'First .. Star - 1) & Base_Name &
+                          Item (Star + 1 .. Item'Last)));
 
                   if Exists (Root & To_String (Name)) then
                      Result.Append (Root & To_String (Name));


### PR DESCRIPTION
Dear Gprbuild developers,

Since Ada2012 the if expression is supported.
Using the if expression in many cases improves the readability of the code.

Greetings,
   Pierre

P.S. When you see no if expression in the change, the code is simplified even further to improve readability.

Problem detected and solved by Rejuvenation-Ada crate
[![vote for Rejuvenation-Ada as The 2022 Ada Crate Of The Year](https://user-images.githubusercontent.com/18348654/191469254-1ca1f4a0-6242-43fa-94a2-f39f55817fdc.jpg)](https://github.com/AdaCore/Ada-SPARK-Crate-Of-The-Year/issues/15)
