### PR TITLE
Add attribute 'Object_File_Prefix' for package Compiler

### DIFF
--- a/gpr/src/gpr-attr.adb
+++ b/gpr/src/gpr-attr.adb
@@ -819,6 +819,13 @@ package body GPR.Attr is
          Attr_Kind  => Case_Insensitive_Associative_Array,
          Conf_Conc  => True);
       Add_Attribute
+      (Name_Object_File_Prefix,
+       Var_Kind   => Single,
+       Attr_Kind  => Case_Insensitive_Associative_Array,
+       Conf_Conc  => False);
+      --  FIXME: SNM: Object_File_Prefix
+      --  Conf_Conc  => False); check this
+      Add_Attribute
         (Name_Object_File_Suffix,
          Var_Kind   => Single,
          Attr_Kind  => Case_Insensitive_Associative_Array,

--- a/gpr/src/gpr-nmsc.adb
+++ b/gpr/src/gpr-nmsc.adb
@@ -907,10 +907,10 @@ package body GPR.Nmsc is
       Id.File                := File_Name;
       Id.Display_File        := Display_File;
       Id.Dep_Name            := Dependency_Name
-                                  (File_Name, Lang_Id.Config.Dependency_Kind);
+        (File_Name, Lang_Id.Config.Dependency_Kind);
       Id.Naming_Exception    := Naming_Exception;
       Id.Object              := Object_Name
-                                  (File_Name, Config.Object_File_Suffix);
+        (File_Name, Config.Object_File_Prefix, Config.Object_File_Suffix);
       Id.Switches            := Switches_Name (File_Name);
 
       --  Add the source id to the Unit_Sources_HT hash table, if the unit name
@@ -1698,6 +1698,20 @@ package body GPR.Nmsc is
                                   Lang_Index.Config.Source_File_Switches,
                                 From_List => Element.Value.Values,
                                 In_Tree   => Data.Tree);
+
+                           --  Attribute Object_File_Prefix (<language>)
+
+                        elsif Current_Array.Name = Name_Object_File_Prefix then
+                           if Get_Name_String (Element.Value.Value) = "" then
+                              Error_Msg
+                              (Data.Flags,
+                               "FIXME: SNM: object file prefix may be empty",
+                               Element.Value.Location, Project);
+
+                           else
+                              Lang_Index.Config.Object_File_Prefix :=
+                              Element.Value.Value;
+                           end if;
 
                            --  Attribute Object_File_Suffix (<language>)
 
@@ -9034,8 +9048,11 @@ package body GPR.Nmsc is
             Id.Dep_Name         :=
               Dependency_Name (Id.File, Id.Language.Config.Dependency_Kind);
             Id.Naming_Exception := Src.Naming_Exception;
-            Id.Object           :=
-              Object_Name (Id.File, Id.Language.Config.Object_File_Suffix);
+            Id.Object           := Object_Name
+              (Id.File,
+               Id.Language.Config.Object_File_Prefix,
+               Id.Language.Config.Object_File_Suffix);
+
             Id.Switches         := Switches_Name (Id.File);
 
             --  Add the source id to the Unit_Sources_HT hash table, if the

--- a/gpr/src/gpr-snames.adb
+++ b/gpr/src/gpr-snames.adb
@@ -249,6 +249,7 @@ package body GPR.Snames is
       Add_Name ("naming");
       Add_Name ("none");
       Add_Name ("object_artifact_extensions");
+      Add_Name ("object_file_prefix");
       Add_Name ("object_file_suffix");
       Add_Name ("object_file_switches");
       Add_Name ("object_generated");

--- a/gpr/src/gpr-snames.ads
+++ b/gpr/src/gpr-snames.ads
@@ -231,6 +231,7 @@ package GPR.Snames is
    Name_Naming                           : constant Name_Id := Name_Id (L) - N;
    Name_None                             : constant Name_Id := Name_Id (L) - N;
    Name_Object_Artifact_Extensions       : constant Name_Id := Name_Id (L) - N;
+   Name_Object_File_Prefix               : constant Name_Id := Name_Id (L) - N;
    Name_Object_File_Suffix               : constant Name_Id := Name_Id (L) - N;
    Name_Object_File_Switches             : constant Name_Id := Name_Id (L) - N;
    Name_Object_Generated                 : constant Name_Id := Name_Id (L) - N;

--- a/gpr/src/gpr-util.adb
+++ b/gpr/src/gpr-util.adb
@@ -2044,7 +2044,9 @@ package body GPR.Util is
             Main_Source_File := Other_Part (Source).File;
             Source.Object :=
               Object_Name
-                (Main_Source_File, Source.Language.Config.Object_File_Suffix);
+               (Main_Source_File,
+                Source.Language.Config.Object_File_Prefix,
+                Source.Language.Config.Object_File_Suffix);
             Source.Dep_Name :=
               Dependency_Name
                 (Source.Object, Source.Language.Config.Dependency_Kind);
@@ -2057,6 +2059,8 @@ package body GPR.Util is
                  Source_Index       => Source.Index,
                  Index_Separator    =>
                    Source.Language.Config.Multi_Unit_Object_Separator,
+                 Object_File_Prefix =>
+                   Source.Language.Config.Object_File_Prefix,
                  Object_File_Suffix =>
                    Source.Language.Config.Object_File_Suffix);
 

--- a/gpr/src/gpr.adb
+++ b/gpr/src/gpr.adb
@@ -1293,15 +1293,33 @@ package body GPR is
 
    function Object_Name
      (Source_File_Name   : File_Name_Type;
+      Object_File_Prefix : Name_Id := No_Name;
       Object_File_Suffix : Name_Id := No_Name) return File_Name_Type
    is
+      Prefixed_Source_File_Name : File_Name_Type;
    begin
+      --  FIXME: SNM: Object_File_Prefix
+
+      --  New_Line;
+      --  Put_Line ("FIXME: SNM: Object_File_Prefix, Put_Lines Debuging:");
+      --  Put_Line ("Source_File_Name = " &
+      --            Get_Name_String (Source_File_Name));
+      --  Put_Line ("Object_File_Prefix = " &
+      --            Get_Name_String (Object_File_Prefix));
+      --  Put_Line ("Object_File_Suffix = " &
+      --            Get_Name_String (Object_File_Suffix));
+      --  New_Line;
+
+      Get_Name_String (Object_File_Prefix);
+      Get_Name_String_And_Append (Source_File_Name);
+      Prefixed_Source_File_Name := Name_Find;
+
       if Object_File_Suffix = No_Name then
          return Extend_Name
-           (Source_File_Name, Object_Suffix);
+           (Prefixed_Source_File_Name, Object_Suffix);
       else
          return Extend_Name
-           (Source_File_Name, Get_Name_String (Object_File_Suffix));
+           (Prefixed_Source_File_Name, Get_Name_String (Object_File_Suffix));
       end if;
    end Object_Name;
 
@@ -1309,13 +1327,16 @@ package body GPR is
      (Source_File_Name   : File_Name_Type;
       Source_Index       : Int;
       Index_Separator    : Character;
+      Object_File_Prefix : Name_Id := No_Name;
       Object_File_Suffix : Name_Id := No_Name) return File_Name_Type
    is
       Index_Img : constant String := Source_Index'Img;
       Last      : Natural;
 
    begin
-      Get_Name_String (Source_File_Name);
+      --  FIXME: SNM: Object_File_Prefix
+      Get_Name_String (Object_File_Prefix);
+      Get_Name_String_And_Append (Source_File_Name);
 
       Last := Name_Len;
       while Last > 1 and then Name_Buffer (Last) /= '.' loop

--- a/gpr/src/gpr.ads
+++ b/gpr/src/gpr.ads
@@ -824,6 +824,9 @@ package GPR is
       --  path name is appended to the last switch in the list.
       --  Example: ("-i", "");
 
+      Object_File_Prefix : Name_Id := No_Name;
+      --  Optional alternate object file prefix
+
       Object_File_Suffix : Name_Id := No_Name;
       --  Optional alternate object file suffix
 
@@ -2588,6 +2591,7 @@ package GPR is
 
    function Object_Name
      (Source_File_Name   : File_Name_Type;
+      Object_File_Prefix : Name_Id := No_Name;
       Object_File_Suffix : Name_Id := No_Name) return File_Name_Type;
    --  Returns the object file name corresponding to a source file name
 
@@ -2595,6 +2599,7 @@ package GPR is
      (Source_File_Name   : File_Name_Type;
       Source_Index       : Int;
       Index_Separator    : Character;
+      Object_File_Prefix : Name_Id := No_Name;
       Object_File_Suffix : Name_Id := No_Name) return File_Name_Type;
    --  Returns the object file name corresponding to a unit in a multi-source
    --  file.

--- a/src/gprbuild-post_compile.adb
+++ b/src/gprbuild-post_compile.adb
@@ -1711,7 +1711,7 @@ package body Gprbuild.Post_Compile is
                              Shared                 => Project_Tree.Shared);
 
                         if not Switches.Default
-			   and then Switches.Kind = List
+                          and then Switches.Kind = List
                         then
                            Write_List
                              (Gprexch.Binding_Options, Switches.Values);

--- a/src/gprlib.adb
+++ b/src/gprlib.adb
@@ -1546,13 +1546,13 @@ procedure Gprlib is
                   if Start_Retrieving then
                      --  Don't store -static and -shared flags, they may cause
                      --  issues when linking with the library.
-                     --  Don't store -lgnat and -lgnarl for encapsulated because
-                     --  libgnat.a and libgnarl.a already encapsulated.
+                     --  Don't store -lgnat and -lgnarl for encapsulated
+                     --  because libgnat.a and libgnarl.a already encapsulated.
 
                      if Line (9 .. Last) not in Dash_Static | Dash_Shared
                        and then not
-                         (Standalone = Encapsulated
-                          and then Line (9 .. Last) in Dash_Lgnat | Dash_Lgnarl)
+                       (Standalone = Encapsulated
+                        and then Line (9 .. Last) in Dash_Lgnat | Dash_Lgnarl)
                      then
                         Put_Line (IO_File, Line (9 .. Last));
                      end if;


### PR DESCRIPTION
Good day!

For examples, output names with prefix use in moc, uic, rcc compilers: https://doc.qt.io/qt-6/moc.html
It is the initial commit.  I will be very glad to see your comments.

--  Prototype of project file
project UIC is
   --  Qt User Interface Compiler
   for Languages use ("UIC");
   for Source_Dirs use ("Src");
   for Object_Dir use "Release";

   for Objects_Linked ("UIC") use "False";

   package Naming is
      for Body_Suffix ("uic") use ".ui";
   end Naming;

   package Compiler is
      for Driver ("UIC") use "/usr/lib/qt5/bin/uic";
      for Object_File_Suffix ("UIC") use ".h";
      for Object_File_Prefix ("UIC") use "ui_";
      for Object_File_Switches ("UIC") use ("-o", "");
   end Compiler;
end UIC;
--

--  output
./gprbuild -vm /home/user_1/Projects/Qt_Examples/Test_1/uic.gpr
GPRBUILD Pro 18.0w (19940713) (x86_64-pc-linux-gnu)
Copyright (C) 2004-2016, AdaCore
 24 lines: No errors
TMPDIR = "/tmp"
gprconfig --batch -o /tmp/GNAT-TEMP-000001.TMP --target=x86_64-pc-linux-gnu --fallback-targets --config=uic,,,,
Error: unknown language 'uic'
Checking configuration /tmp/GNAT-TEMP-000001.TMP
Setting the default project search directories
   Adding directory "/usr/lib/qt5/x86_64-pc-linux-gnu/share/gpr"
   Adding directory "/usr/lib/qt5/x86_64-pc-linux-gnu/lib/gnat"
   Adding directory "/usr/lib/qt5/x86_64-linux/share/gpr"
   Adding directory "/usr/lib/qt5/x86_64-linux/lib/gnat"
   Adding directory "/usr/lib/qt5/share/gpr"
   Adding directory "/usr/lib/qt5/lib/gnat"
gprconfig --batch -o /tmp/GNAT-TEMP-000002.TMP --target=x86_64-pc-linux-gnu --fallback-targets --config=uic,,,,
Error: unknown language 'uic'
Checking configuration /tmp/GNAT-TEMP-000002.TMP
Setting the default project search directories
   Adding directory "/usr/lib/qt5/x86_64-pc-linux-gnu/share/gpr"
   Adding directory "/usr/lib/qt5/x86_64-pc-linux-gnu/lib/gnat"
   Adding directory "/usr/lib/qt5/x86_64-linux/share/gpr"
   Adding directory "/usr/lib/qt5/x86_64-linux/lib/gnat"
   Adding directory "/usr/lib/qt5/share/gpr"
   Adding directory "/usr/lib/qt5/lib/gnat"
   Checking /home/user_1/Projects/Qt_Examples/Test_1/Src/mainwindow.ui ... 
      -> object file /home/curator/Projects/Qt_Examples/Test_1/Release/ui_mainwindow.h does not exist
Changing to object directory of "UIC": "/home/curator/Projects/Qt_Examples/Test_1/Release/"
/usr/lib/qt5/bin/uic /home/curator/Projects/Qt_Examples/Test_1/Src/mainwindow.ui -o ui_mainwindow.h

