### PR TITLE
Provide specific external for library type.

### DIFF
--- a/gpr/gpr.gpr
+++ b/gpr/gpr.gpr
@@ -30,7 +30,8 @@ library project GPR is
    Target : Target_Type := external ("OS", "UNIX");
 
    type Library_Type_Type is ("relocatable", "static", "static-pic");
-   Gnat_Lib_Type : Library_Type_Type := external ("LIBRARY_TYPE", "static");
+   Gnat_Lib_Type : Library_Type_Type := external
+     ("LIBRARY_TYPE", external ("GPR_LIBRARY_TYPE", "static"));
    Root_Obj_Dir := external ("OBJDIR", ".");
 
    for Library_Kind use Gnat_Lib_Type;

--- a/gpr/gpr.gpr
+++ b/gpr/gpr.gpr
@@ -31,7 +31,7 @@ library project GPR is
 
    type Library_Type_Type is ("relocatable", "static", "static-pic");
    Gnat_Lib_Type : Library_Type_Type := external
-     ("LIBRARY_TYPE", external ("GPR_LIBRARY_TYPE", "static"));
+     ("GPR_LIBRARY_TYPE", external ("LIBRARY_TYPE", "static"));
    Root_Obj_Dir := external ("OBJDIR", ".");
 
    for Library_Kind use Gnat_Lib_Type;


### PR DESCRIPTION
  * gpr/gpr.gpr (Gnat_Lib_Type): new external GPR_LIBRARY_TYPE, acts as the default for LIBRARY_TYPE.