### PR TITLE
Fix toolchain detection localization issues on GNU systems

### DIFF
--- a/gpr/src/gpr-knowledge.adb
+++ b/gpr/src/gpr-knowledge.adb
@@ -2000,11 +2000,29 @@ package body GPR.Knowledge is
                      Command : constant String :=
                                  Substitute_Variables_In_Compiler_Description
                                    (Get_Name_String (Node.Command), Comp);
+                     Locale_Msg_Save : constant String :=
+                        (if Ada.Environment_Variables.Exists ("LC_MESSAGES")
+                         then Ada.Environment_Variables.Value ("LC_MESSAGES")
+                         else "");
                   begin
+                     --  use C locale for gathering toolchain information to
+                     --  get consistent results across systems with different
+                     --  locales and charsets.
+                     --
+                     --  Fixes issue gprconfig_kb#23 and similar cases
+                     Ada.Environment_Variables.Set ("LC_MESSAGES", "C");
+
                      Tmp_Result := Null_Unbounded_String;
                      Tmp_Result := Get_Command_Output_Cache
                        (Get_Name_String (Comp.Path), Command);
                      Ada.Environment_Variables.Set ("PATH", Saved_Path);
+
+                     if Locale_Msg_Save'Length /= 0 then
+                        Ada.Environment_Variables.Set
+                           ("LC_MESSAGES", Locale_Msg_Save);
+                     else
+                        Ada.Environment_Variables.Clear ("LC_MESSAGES");
+                     end if;
 
                      if Current_Verbosity = High then
                         Put_Verbose (Attribute & ": executing """ & Command
@@ -2018,6 +2036,14 @@ package body GPR.Knowledge is
                   exception
                      when Invalid_Process =>
                         Put_Verbose ("Spawn failed for " & Command);
+                        --  restore messages locale
+                        if Locale_Msg_Save'Length /= 0 then
+                           Ada.Environment_Variables.Set
+                              ("LC_MESSAGES", Locale_Msg_Save);
+                        else
+                           Ada.Environment_Variables.Clear ("LC_MESSAGES");
+                        end if;
+
                   end;
 
                when Value_Directory =>


### PR DESCRIPTION
Greetings,

GCC provides localized version output with different formatting depending on the system locale. This behaviour breaks gprconfig on all GNU/Linux distributions on which GCC is compiled with gettext support when using a non-english locale.
In my case, ```gcc -v``` yields ```gcc-Version 15.2.1 20260209 (GCC)```, whereas the non-localized output should be ```gcc version 15.2.1 20260209 (GCC)``` (note the '-').
There have been attempts to [add/change regexes in gprconfig_kb](https://github.com/AdaCore/gprconfig_kb/issues/21) and AFAIK some distribution maintainers have created patches for the XML files, but rather than adding various bits and pieces to the knowledge base I think it makes more sense to generate a uniform version output in the first place. This would obviously accommodate for future changes in the gettext output as well.

This changeset defines the LC_MESSAGES variable to `C` before generating the version output and resets it afterwards, so that always the default version info is used for searching in the knowledge base.